### PR TITLE
feat: Release v1.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -755,8 +755,8 @@ secrets:
 <summary><b>What happens if I delete a database row?</b></summary>
 
 The Tenant CR is automatically deleted, triggering cleanup:
-- `deletionPolicy: Delete` (default): Resources are deleted
-- `deletionPolicy: Retain`: Resources kept, owner references removed
+- `deletionPolicy: Delete` (default): Resources are deleted (automatic via ownerReference)
+- `deletionPolicy: Retain`: Resources kept (no ownerReference set, label-based tracking only)
 </details>
 
 <details>

--- a/api/v1/tenanttemplate_types.go
+++ b/api/v1/tenanttemplate_types.go
@@ -29,51 +29,74 @@ import (
 type TenantTemplateSpec struct {
 	// RegistryID references the TenantRegistry that this template is associated with
 	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="registryId is immutable"
 	RegistryID string `json:"registryId"`
 
 	// ServiceAccounts defines ServiceAccount resources to create
 	// +optional
+	// +listType=map
+	// +listMapKey=id
 	ServiceAccounts []TResource `json:"serviceAccounts,omitempty"`
 
 	// Deployments defines Deployment resources to create
 	// +optional
+	// +listType=map
+	// +listMapKey=id
 	Deployments []TResource `json:"deployments,omitempty"`
 
 	// StatefulSets defines StatefulSet resources to create
 	// +optional
+	// +listType=map
+	// +listMapKey=id
 	StatefulSets []TResource `json:"statefulSets,omitempty"`
 
 	// Services defines Service resources to create
 	// +optional
+	// +listType=map
+	// +listMapKey=id
 	Services []TResource `json:"services,omitempty"`
 
 	// Ingresses defines Ingress resources to create
 	// +optional
+	// +listType=map
+	// +listMapKey=id
 	Ingresses []TResource `json:"ingresses,omitempty"`
 
 	// ConfigMaps defines ConfigMap resources to create
 	// +optional
+	// +listType=map
+	// +listMapKey=id
 	ConfigMaps []TResource `json:"configMaps,omitempty"`
 
 	// Secrets defines Secret resources to create
 	// +optional
+	// +listType=map
+	// +listMapKey=id
 	Secrets []TResource `json:"secrets,omitempty"`
 
 	// PersistentVolumeClaims defines PVC resources to create
 	// +optional
+	// +listType=map
+	// +listMapKey=id
 	PersistentVolumeClaims []TResource `json:"persistentVolumeClaims,omitempty"`
 
 	// Jobs defines Job resources to create
 	// +optional
+	// +listType=map
+	// +listMapKey=id
 	Jobs []TResource `json:"jobs,omitempty"`
 
 	// CronJobs defines CronJob resources to create
 	// +optional
+	// +listType=map
+	// +listMapKey=id
 	CronJobs []TResource `json:"cronJobs,omitempty"`
 
 	// Manifests defines arbitrary Kubernetes resources as raw manifests
 	// Use this for any resource type not explicitly supported above
 	// +optional
+	// +listType=map
+	// +listMapKey=id
 	Manifests []TResource `json:"manifests,omitempty"`
 }
 

--- a/config/crd/bases/operator.kubernetes-tenants.org_tenanttemplates.yaml
+++ b/config/crd/bases/operator.kubernetes-tenants.org_tenanttemplates.yaml
@@ -165,6 +165,9 @@ spec:
                   - spec
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - id
+                x-kubernetes-list-type: map
               cronJobs:
                 description: CronJobs defines CronJob resources to create
                 items:
@@ -268,6 +271,9 @@ spec:
                   - spec
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - id
+                x-kubernetes-list-type: map
               deployments:
                 description: Deployments defines Deployment resources to create
                 items:
@@ -371,6 +377,9 @@ spec:
                   - spec
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - id
+                x-kubernetes-list-type: map
               ingresses:
                 description: Ingresses defines Ingress resources to create
                 items:
@@ -474,6 +483,9 @@ spec:
                   - spec
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - id
+                x-kubernetes-list-type: map
               jobs:
                 description: Jobs defines Job resources to create
                 items:
@@ -577,6 +589,9 @@ spec:
                   - spec
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - id
+                x-kubernetes-list-type: map
               manifests:
                 description: |-
                   Manifests defines arbitrary Kubernetes resources as raw manifests
@@ -682,6 +697,9 @@ spec:
                   - spec
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - id
+                x-kubernetes-list-type: map
               persistentVolumeClaims:
                 description: PersistentVolumeClaims defines PVC resources to create
                 items:
@@ -785,10 +803,16 @@ spec:
                   - spec
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - id
+                x-kubernetes-list-type: map
               registryId:
                 description: RegistryID references the TenantRegistry that this template
                   is associated with
                 type: string
+                x-kubernetes-validations:
+                - message: registryId is immutable
+                  rule: self == oldSelf
               secrets:
                 description: Secrets defines Secret resources to create
                 items:
@@ -892,6 +916,9 @@ spec:
                   - spec
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - id
+                x-kubernetes-list-type: map
               serviceAccounts:
                 description: ServiceAccounts defines ServiceAccount resources to create
                 items:
@@ -995,6 +1022,9 @@ spec:
                   - spec
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - id
+                x-kubernetes-list-type: map
               services:
                 description: Services defines Service resources to create
                 items:
@@ -1098,6 +1128,9 @@ spec:
                   - spec
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - id
+                x-kubernetes-list-type: map
               statefulSets:
                 description: StatefulSets defines StatefulSet resources to create
                 items:
@@ -1201,6 +1234,9 @@ spec:
                   - spec
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - id
+                x-kubernetes-list-type: map
             required:
             - registryId
             type: object

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -151,7 +151,7 @@ spec:
 | Policy | Effect | Default |
 | --- | --- | --- |
 | `creationPolicy` | When `Once`, the controller never recreates deleted resources. `WhenNeeded` reconciles on every sync. | `WhenNeeded` |
-| `deletionPolicy` | `Retain` keeps objects after a tenant is deleted; `Delete` cleans them up. | `Delete` |
+| `deletionPolicy` | `Retain` keeps objects (no ownerReference, label-based tracking); `Delete` cleans them up (with ownerReference). | `Delete` |
 | `conflictPolicy` | `Force` overwrites conflicting fields; `Stuck` marks the resource as failed for manual intervention. | `Stuck` |
 | `patchStrategy` | Determines how the resource spec is applied. Use `merge` for strategic merge resources. | `apply` |
 :::

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -59,7 +59,7 @@ A Custom Resource representing a single tenant instance. Automatically created b
 - Created/deleted automatically (users typically don't create manually)
 - Contains resolved resource specifications (templates already evaluated)
 - Tracks status of all provisioned resources
-- Owns all created Kubernetes resources via ownerReferences
+- Owns created resources via ownerReferences (Delete policy) or labels (Retain policy)
 
 ## Data Source Concepts
 
@@ -258,9 +258,9 @@ The base structure for all resources in TenantTemplate. Contains:
 A Kubernetes metadata field that establishes parent-child relationships between resources.
 
 **In Tenant Operator:**
-- All created resources have `ownerReference` pointing to their Tenant CR
-- Enables automatic garbage collection when Tenant is deleted
-- Exception: Resources with `deletionPolicy: Retain`
+- Resources with `deletionPolicy: Delete` (default) have `ownerReference` pointing to their Tenant CR
+- Enables automatic garbage collection by Kubernetes when Tenant is deleted
+- Resources with `deletionPolicy: Retain` use label-based tracking instead (NO ownerReference)
 
 ### Drift Detection
 
@@ -300,11 +300,11 @@ Controls when resources are created/updated.
 
 ### DeletionPolicy
 
-Controls what happens to resources when Tenant CR is deleted.
+Controls resource lifecycle and tracking mechanism. Evaluated at resource **creation time**, not deletion time.
 
 **Values:**
-- `Delete` (default) - Remove resource from cluster
-- `Retain` - Remove ownerReference, keep resource in cluster
+- `Delete` (default) - Uses ownerReference for automatic cleanup when Tenant is deleted
+- `Retain` - Uses label-based tracking only (no ownerReference), resource persists after Tenant deletion
 
 **Use cases for `Retain`:**
 - Persistent data (PVCs, Databases)


### PR DESCRIPTION
## Overview

This release significantly improves Terraform compatibility and enhances resource lifecycle management with better deletion policies and orphan handling.

## Key Features

### 🔧 Terraform Compatibility Improvements

**Problem**: Terraform was forcing recreate of TenantTemplate resources even when only modifying nested resource definitions (deployments, secrets, etc.), causing unnecessary disruption.

**Solution**:
- Added `x-kubernetes-validations` to mark `registryId` as immutable
  - Prevents accidental changes to template-registry binding
  - Provides clear error messages when immutable fields are modified
- Implemented `x-kubernetes-list-type: map` with `id` as map key for all resource arrays
  - Enables Terraform to track individual resources by their ID
  - Allows in-place updates instead of full resource recreation
  - Supports granular changes to specific deployments, services, etc.

**Impact**: Users can now modify TenantTemplate specs (e.g., change image tags, replicas) without triggering resource recreation, significantly improving operational stability.

### 🗑️ Enhanced Resource Lifecycle Management

**Deletion Policy Improvements**:
- Clarified deletion policy behavior in documentation and code comments
- Implemented label-based tracking for resources with `DeletionPolicy=Retain`
  - Prevents Kubernetes garbage collector from auto-deleting retained resources
  - Adds tracking labels: `kubernetes-tenants.org/tenant`, `kubernetes-tenants.org/tenant-namespace`
- Fixed critical issue: DeletionPolicy now evaluated at creation time (not deletion time)

**Orphan Resource Handling**:
- Enhanced orphan markers with detailed annotations:
  - `kubernetes-tenants.org/orphaned: "true"` (label for queries)
  - `kubernetes-tenants.org/orphaned-at: "<RFC3339 timestamp>"`
  - `kubernetes-tenants.org/orphaned-reason: "RemovedFromTemplate" | "TenantDeleted"`
- Improved orphan cleanup logic to read DeletionPolicy from resource annotations
  - Critical: Ensures correct cleanup even after template changes
  - Orphaned resources preserve their original DeletionPolicy
- Automatic re-adoption of previously orphaned resources when re-added to templates

**Impact**: Better resource lifecycle control, preventing accidental deletions and providing clear audit trails for orphaned resources.

## Breaking Changes

None. All changes are backward compatible.

## Requirements

- Kubernetes 1.25+ (for CEL validation support)

## Files Changed

- `api/v1/tenanttemplate_types.go`: Added immutable validation and list-type annotations
- `config/crd/bases/operator.kubernetes-tenants.org_tenanttemplates.yaml`: Generated CRD with enhanced metadata
- `internal/apply/ssa.go`: Enhanced deletion policy and orphan handling logic
- `internal/controller/tenant_controller.go`: Improved resource lifecycle management
- Documentation updates: `CLAUDE.md`, `README.md`, `docs/` (api, policies, templates)

## Migration Guide

To use this release:
1. Apply updated CRDs: `kubectl apply -f config/crd/bases/`
2. Restart operator (if already deployed): `kubectl rollout restart deployment tenant-operator -n tenant-operator-system`
3. Existing TenantTemplate resources automatically adopt new schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)