### PR TITLE
Release v1.1.13

### DIFF
--- a/internal/controller/main_reconciliation_test.go
+++ b/internal/controller/main_reconciliation_test.go
@@ -472,7 +472,7 @@ func TestLynqFormValidation(t *testing.T) {
 		// Should have Valid condition set to False
 		var validCondition *metav1.Condition
 		for i := range updatedTemplate.Status.Conditions {
-			if updatedTemplate.Status.Conditions[i].Type == "Valid" {
+			if updatedTemplate.Status.Conditions[i].Type == ConditionTypeValid {
 				validCondition = &updatedTemplate.Status.Conditions[i]
 				break
 			}


### PR DESCRIPTION
## Summary

This release significantly reduces log volume and event noise in the Lynq operator,
addressing potential load issues on cluster log collectors. The operator now produces
logs and events only when meaningful state changes occur.

## Changes

### Log Reduction
- Change full reconcile path logs to DEBUG level (V(1))
- Reduce INFO-level logs during steady-state operations
- Estimated reduction: ~1300 lines/minute → minimal (no-change = no logs)

### Event Optimization
- **LynqForm Controller**: `ValidationPassed` events only fire on state transitions
- **LynqHub Controller**: Remove redundant `NodeUpdated` events when no actual changes occur
- **LynqHub Controller**: Fix template comparison to use correct template per node

### Bug Fixes
- **Critical**: Add `ObservedGeneration` update in `reconcileSpec` to prevent repeated full reconciles
- **Critical**: Ensure full reconcile runs when node is Degraded or has failed resources (conflict recovery)
- Fix `shouldUpdateLynqNode` to compare against the correct template using `node.Spec.TemplateRef`

### Code Cleanup
- Remove deprecated `getTemplateForRegistry` function
- Add `ConditionTypeValid` and `ConditionTypeApplied` constants for LynqForm

## Impact

- Reduces API server load from unnecessary reconciliations
- Prevents log collector overload in production clusters
- Maintains proper conflict recovery behavior