### PR TITLE
perf: eliminate LynqNode reconcile feedback loop and hot-path waste

### DIFF
--- a/internal/controller/lynqhub_controller.go
+++ b/internal/controller/lynqhub_controller.go
@@ -204,14 +204,16 @@ func (r *LynqHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// updates made within this loop iteration
 	updatedInThisIteration := make(map[string]int32)
 
+	// Memoize the per-template "currently updating" count for the duration of this Reconcile.
+	skew := newRolloutSkewCounter(r, nodesByTemplate)
+
 	// Create/update nodes for each template-row combination
 	for key, desired := range desired {
 		tmpl := desired.Template
-		templateNodes := nodesByTemplate[tmpl.Name]
 
 		if existingLynqNode, exists := existing[key]; !exists {
 			// Create new LynqNode - check maxSkew before creating
-			if r.canUpdateNodeWithCount(ctx, tmpl, templateNodes, updatedInThisIteration[tmpl.Name]) {
+			if canUpdateNodeWithPrecount(tmpl, skew.count(ctx, tmpl), updatedInThisIteration[tmpl.Name]) {
 				if err := r.createLynqNode(ctx, registry, tmpl, desired.Row); err != nil {
 					// Ignore AlreadyExists errors (can happen due to concurrent reconciliations)
 					if !errors.IsAlreadyExists(err) {
@@ -229,7 +231,7 @@ func (r *LynqHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			// Update existing LynqNode if data or template changed
 			if r.shouldUpdateLynqNode(ctx, registry, existingLynqNode, desired.Row, templateMap) {
 				// Check maxSkew before updating
-				if r.canUpdateNodeWithCount(ctx, tmpl, templateNodes, updatedInThisIteration[tmpl.Name]) {
+				if canUpdateNodeWithPrecount(tmpl, skew.count(ctx, tmpl), updatedInThisIteration[tmpl.Name]) {
 					if err := r.updateLynqNode(ctx, registry, tmpl, existingLynqNode, desired.Row); err != nil {
 						logger.Error(err, "Failed to update LynqNode", "template", key.TemplateName, "uid", key.UID)
 					} else {
@@ -252,7 +254,7 @@ func (r *LynqHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				r.Recorder.Eventf(registry, corev1.EventTypeNormal, "RolloutThrottled",
 					"LynqForm '%s': %d node updates throttled (maxSkew=%d, currently updating=%d)",
 					tmplName, throttledCount, tmpl.Spec.Rollout.MaxSkew,
-					r.countUpdatingNodes(ctx, nodesByTemplate[tmplName], tmpl.Generation))
+					skew.count(ctx, tmpl))
 				break
 			}
 		}
@@ -401,7 +403,7 @@ func (r *LynqHubReconciler) renderAllTemplateResources(
 	tmpl *lynqv1.LynqForm,
 	vars template.Variables,
 ) (*lynqv1.LynqNodeSpec, error) {
-	engine := template.NewEngine()
+	engine := template.SharedEngine()
 
 	spec := &lynqv1.LynqNodeSpec{
 		ServiceAccounts:          make([]lynqv1.TResource, 0),
@@ -1425,6 +1427,62 @@ func (r *LynqHubReconciler) canUpdateNodeWithCount(ctx context.Context, tmpl *ly
 
 	// Count nodes that are already updating based on their stored state
 	updatingCount := r.countUpdatingNodes(ctx, templateNodes, tmpl.Generation)
+
+	return canUpdateNodeWithPrecount(tmpl, updatingCount, additionalUpdates)
+}
+
+// rolloutSkewCounter memoizes countUpdatingNodes per template for the duration of one hub
+// Reconcile. See canUpdateNodeWithPrecount for why the count is stable within a Reconcile and
+// why recomputing it per desired node was expensive.
+type rolloutSkewCounter struct {
+	reconciler      *LynqHubReconciler
+	nodesByTemplate map[string][]*lynqv1.LynqNode
+	counts          map[string]int32
+}
+
+func newRolloutSkewCounter(r *LynqHubReconciler, nodesByTemplate map[string][]*lynqv1.LynqNode) *rolloutSkewCounter {
+	return &rolloutSkewCounter{
+		reconciler:      r,
+		nodesByTemplate: nodesByTemplate,
+		counts:          make(map[string]int32, len(nodesByTemplate)),
+	}
+}
+
+// count returns how many of the template's nodes are currently updating.
+//
+// Returns 0 without scanning when the template has no rollout limit: the result is not
+// consulted in that case (canUpdateNodeWithPrecount short-circuits), so paying for the scan
+// would be pure waste.
+func (c *rolloutSkewCounter) count(ctx context.Context, tmpl *lynqv1.LynqForm) int32 {
+	if tmpl.Spec.Rollout == nil || tmpl.Spec.Rollout.MaxSkew == 0 {
+		return 0
+	}
+	if cached, ok := c.counts[tmpl.Name]; ok {
+		return cached
+	}
+	count := c.reconciler.countUpdatingNodes(ctx, c.nodesByTemplate[tmpl.Name], tmpl.Generation)
+	c.counts[tmpl.Name] = count
+	return count
+}
+
+// canUpdateNodeWithPrecount is canUpdateNodeWithCount with the countUpdatingNodes result
+// supplied by the caller.
+//
+// countUpdatingNodes depends only on (templateNodes, tmpl.Generation). Both are fixed for the
+// duration of one Reconcile: nodesByTemplate is built from a single List snapshot before the
+// desired-set loop, and nothing in that loop mutates the slice or the LynqNode objects it points
+// at (updateLynqNode re-Gets its own `latest` copy). Calling it once per desired node therefore
+// recomputed an identical answer O(rows) times, and each computation scans every node for the
+// template and issues a cached workload GET (plus DeepCopy) per applied resource — in production
+// that was 360 desired x 120 nodes = 43,200 scans on every 30s hub sync.
+//
+// Updates made earlier in the same loop are already accounted for by the caller's
+// additionalUpdates counter, so hoisting the count out of the loop preserves maxSkew semantics
+// exactly.
+func canUpdateNodeWithPrecount(tmpl *lynqv1.LynqForm, updatingCount, additionalUpdates int32) bool {
+	if tmpl.Spec.Rollout == nil || tmpl.Spec.Rollout.MaxSkew == 0 {
+		return true
+	}
 
 	// Add the count of nodes we've updated in THIS iteration that aren't yet reflected in templateNodes
 	totalUpdating := updatingCount + additionalUpdates

--- a/internal/controller/lynqnode_controller.go
+++ b/internal/controller/lynqnode_controller.go
@@ -22,10 +22,12 @@ import (
 	errorsStd "errors"
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -100,7 +102,7 @@ func (r *LynqNodeReconciler) getTemplateEngine() *template.Engine {
 	if r.TemplateEngine != nil {
 		return r.TemplateEngine
 	}
-	return template.NewEngine()
+	return template.SharedEngine()
 }
 
 func (r *LynqNodeReconciler) getApplier() *apply.Applier {
@@ -260,6 +262,9 @@ func (r *LynqNodeReconciler) applyResources(ctx context.Context, node *lynqv1.Ly
 	progressingSet := false
 	templateAppliedEventEmitted := false
 
+	// Rate-limits the mid-loop "is this LynqNode being deleted?" probe. See isDeleting.
+	deletionGate := &nodeDeletionGate{}
+
 	// Track failed resource IDs to skip dependent resources (actual failures)
 	failedResourceIds := make(map[string]bool)
 	// Track not-ready resource IDs to block dependent resources (still progressing, not failed)
@@ -334,21 +339,16 @@ func (r *LynqNodeReconciler) applyResources(ctx context.Context, node *lynqv1.Ly
 			continue
 		}
 
-		// Check if node is being deleted before processing each resource
-		// This allows quick exit when node is deleted during reconciliation
-		currentLynqNode := &lynqv1.LynqNode{}
-		if err := r.Get(ctx, client.ObjectKeyFromObject(node), currentLynqNode); err != nil {
-			if errors.IsNotFound(err) {
-				// LynqNode was deleted, stop processing
-				logger.Info("LynqNode deleted during reconciliation, stopping resource application")
-				return readyCount, failedCount, changedCount, conflictedCount, skippedCount, skippedIds
-			}
-			// Continue on other errors
-		} else if !currentLynqNode.DeletionTimestamp.IsZero() {
-			// LynqNode is being deleted, stop processing immediately
-			logger.Info("LynqNode deletion in progress, stopping resource application",
-				"node", node.Name,
-				"processedResources", readyCount+failedCount)
+		// Check if node is being deleted before processing each resource.
+		// This allows quick exit when node is deleted during reconciliation.
+		//
+		// Throttled: this Get is a cache read, but the cached client hands back a DeepCopy of
+		// the whole LynqNode, and a LynqNode carries every resolved resource spec (~24KB in
+		// production). Doing that once per resource meant re-copying the entire CR R times per
+		// reconcile for a single timestamp check. The loop body is non-blocking (readiness is
+		// sampled, never waited on), so re-checking on a time interval rather than on every
+		// iteration detects deletion just as promptly in wall-clock terms.
+		if deletionGate.isDeleting(ctx, r.Client, node, logger, readyCount+failedCount) {
 			return readyCount, failedCount, changedCount, conflictedCount, skippedCount, skippedIds
 		}
 
@@ -527,6 +527,65 @@ func (r *LynqNodeReconciler) applyResources(ctx context.Context, node *lynqv1.Ly
 	}
 
 	return readyCount, failedCount, changedCount, conflictedCount, skippedCount, skippedIds
+}
+
+// nodeDeletionCheckInterval bounds how often applyResources re-reads the LynqNode to notice
+// that it has been deleted mid-loop. The loop body never blocks, so a resource-count-driven
+// check and a time-driven check are equivalent in wall-clock terms; the time-driven one just
+// does not scale its cost with the number of resources in the template.
+const nodeDeletionCheckInterval = 250 * time.Millisecond
+
+// nodeDeletionGate throttles the mid-loop LynqNode deletion probe in applyResources.
+//
+// The probe is a cached read, but the cached client returns a DeepCopy, and a LynqNode embeds
+// every resolved resource spec (~24KB in production). Probing per resource re-copied the whole
+// CR R times per reconcile to read one timestamp. The zero value is ready to use and probes on
+// first call.
+type nodeDeletionGate struct {
+	lastCheck time.Time
+	deleting  bool
+}
+
+// isDeleting reports whether the LynqNode has been deleted or has a DeletionTimestamp, so the
+// caller should stop applying resources. Results are reused for nodeDeletionCheckInterval.
+//
+// Transient read errors other than NotFound are treated as "not deleting" and are not cached,
+// matching the previous behavior of falling through to continue processing.
+func (g *nodeDeletionGate) isDeleting(
+	ctx context.Context,
+	c client.Client,
+	node *lynqv1.LynqNode,
+	logger logr.Logger,
+	processedResources int32,
+) bool {
+	if g.deleting {
+		return true
+	}
+	if !g.lastCheck.IsZero() && time.Since(g.lastCheck) < nodeDeletionCheckInterval {
+		return false
+	}
+	g.lastCheck = time.Now()
+
+	current := &lynqv1.LynqNode{}
+	if err := c.Get(ctx, client.ObjectKeyFromObject(node), current); err != nil {
+		if errors.IsNotFound(err) {
+			logger.Info("LynqNode deleted during reconciliation, stopping resource application")
+			g.deleting = true
+			return true
+		}
+		// Continue on other errors
+		return false
+	}
+
+	if !current.DeletionTimestamp.IsZero() {
+		logger.Info("LynqNode deletion in progress, stopping resource application",
+			"node", node.Name,
+			"processedResources", processedResources)
+		g.deleting = true
+		return true
+	}
+
+	return false
 }
 
 // emitTemplateAppliedEvent emits a detailed event when template changes are being applied
@@ -1883,11 +1942,23 @@ func (r *LynqNodeReconciler) reconcileSpec(ctx context.Context, node *lynqv1.Lyn
 		r.StatusManager.PublishLastFullReconcileAt(node, now)
 	}
 
-	// Build applied resource keys
+	// Build applied resource keys.
+	//
+	// MUST be sorted. currentKeys is a map, and Go randomizes map iteration order, so an
+	// unsorted slice here produces a differently-ordered status.appliedResources on every
+	// reconcile. The API server only elides an update when the serialized object is
+	// byte-identical, so a reordered slice is a real etcd write -> resourceVersion bump ->
+	// LynqNode watch event -> another reconcile -> another reordering. That closed a
+	// self-sustaining full-reconcile loop that ran continuously in production (measured:
+	// 200 of 360 LynqNodes written per minute on a fully-Ready, idle cluster).
+	//
+	// Order is not otherwise observable: appliedResources is consumed as a set by
+	// findOrphanedResources and parsed per-element by parseAppliedResource.
 	appliedResourceKeys := make([]string, 0, len(currentKeys))
 	for key := range currentKeys {
 		appliedResourceKeys = append(appliedResourceKeys, key)
 	}
+	sort.Strings(appliedResourceKeys)
 
 	// Calculate complete status using centralized logic
 	statusUpdate := r.calculateLynqNodeStatus(

--- a/internal/controller/reconcile_loop_regression_test.go
+++ b/internal/controller/reconcile_loop_regression_test.go
@@ -1,0 +1,186 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	lynqv1 "github.com/k8s-lynq/lynq/api/v1"
+	"github.com/k8s-lynq/lynq/internal/status"
+)
+
+// multiResourceLynqNode returns a LynqNode carrying enough resources that a map-ordered
+// status.appliedResources would almost certainly differ between two reconciles (1 - 1/n!).
+func multiResourceLynqNode() *lynqv1.LynqNode {
+	configMap := func(id, name string) lynqv1.TResource {
+		return lynqv1.TResource{
+			ID:           id,
+			NameTemplate: name,
+			Spec: unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"data":       map[string]interface{}{"app": "myapp"},
+				},
+			},
+			CreationPolicy: lynqv1.CreationPolicyWhenNeeded,
+			DeletionPolicy: lynqv1.DeletionPolicyDelete,
+		}
+	}
+
+	return &lynqv1.LynqNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "node1-web-app",
+			Namespace: "default",
+			Annotations: map[string]string{
+				"lynq.sh/hostOrUrl": "https://tenant1.example.com",
+				"lynq.sh/activate":  "true",
+				"lynq.sh/extra":     `{"plan":"premium"}`,
+			},
+		},
+		Spec: lynqv1.LynqNodeSpec{
+			UID:         "node1",
+			TemplateRef: "web-app",
+			ConfigMaps: []lynqv1.TResource{
+				configMap("zeta-config", "node1-zeta"),
+				configMap("alpha-config", "node1-alpha"),
+				configMap("mike-config", "node1-mike"),
+				configMap("delta-config", "node1-delta"),
+				configMap("bravo-config", "node1-bravo"),
+				configMap("yankee-config", "node1-yankee"),
+				configMap("charlie-config", "node1-charlie"),
+			},
+		},
+	}
+}
+
+// TestRegression_SteadyStateReconcileDoesNotWriteStatus pins the invariant that broke in
+// production: reconciling an unchanged LynqNode must not write to the API server.
+//
+// Two independent defects combined into a self-sustaining full-reconcile loop:
+//
+//  1. status.appliedResources was assembled by ranging over a map, so its order was
+//     re-randomized on every reconcile. The API server only elides an update when the
+//     serialized object is byte-identical, so a reordered slice is a genuine etcd write.
+//  2. StatusManager marked every published field as changed without comparing it to the
+//     stored value, so Status().Update() was issued on every reconcile regardless.
+//
+// Either write bumps resourceVersion, which fires a LynqNode watch event, which re-enqueues
+// the node — forever. Measured in production: 200 of 360 LynqNodes written per minute on a
+// fully-Ready, idle cluster, with the manager pinned at 671m CPU.
+//
+// Asserting on resourceVersion covers both defects at once, and covers any future field that
+// reintroduces the same class of instability.
+func TestRegression_SteadyStateReconcileDoesNotWriteStatus(t *testing.T) {
+	ctx := context.Background()
+	scheme := setupTestScheme(t)
+	node := multiResourceLynqNode()
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(node).
+		WithStatusSubresource(node).
+		Build()
+
+	r := &LynqNodeReconciler{
+		Client:        fakeClient,
+		Scheme:        scheme,
+		Recorder:      record.NewFakeRecorder(1000),
+		StatusManager: status.NewManager(fakeClient, status.WithSyncMode()),
+	}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: node.Name, Namespace: node.Namespace}}
+
+	resourceVersion := func() string {
+		current := &lynqv1.LynqNode{}
+		require.NoError(t, fakeClient.Get(ctx, req.NamespacedName, current))
+		return current.ResourceVersion
+	}
+
+	// Given a LynqNode that has settled: the finalizer is on, resources have been applied
+	// once, and status reflects the outcome.
+	for i := 0; i < 3; i++ {
+		_, err := r.Reconcile(ctx, req)
+		// The fake client does not implement Server-Side Apply, so applies may fail. That is
+		// irrelevant here: the loop is driven by status writes, and a stable failure produces
+		// a stable status just as a stable success does.
+		_ = err
+	}
+	settled := resourceVersion()
+
+	// When the node is reconciled repeatedly with nothing changed
+	for i := 0; i < 5; i++ {
+		_, err := r.Reconcile(ctx, req)
+		_ = err
+	}
+
+	// Then the object is never written again, so no watch event is produced and the loop
+	// cannot sustain itself.
+	assert.Equal(t, settled, resourceVersion(),
+		"steady-state reconcile wrote to the LynqNode; each such write re-triggers reconciliation")
+}
+
+// TestRegression_AppliedResourcesIsSorted pins the ordering invariant directly, independent of
+// whether StatusManager happens to suppress the write. status.appliedResources is built from a
+// map and Go randomizes map iteration, so it must be sorted before it is published.
+func TestRegression_AppliedResourcesIsSorted(t *testing.T) {
+	ctx := context.Background()
+	scheme := setupTestScheme(t)
+	node := multiResourceLynqNode()
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(node).
+		WithStatusSubresource(node).
+		Build()
+
+	r := &LynqNodeReconciler{
+		Client:        fakeClient,
+		Scheme:        scheme,
+		Recorder:      record.NewFakeRecorder(1000),
+		StatusManager: status.NewManager(fakeClient, status.WithSyncMode()),
+	}
+
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: node.Name, Namespace: node.Namespace}}
+
+	// Given a reconciled LynqNode with several resources
+	for i := 0; i < 2; i++ {
+		_, err := r.Reconcile(ctx, req)
+		_ = err
+	}
+
+	// When its recorded applied resources are read back
+	current := &lynqv1.LynqNode{}
+	require.NoError(t, fakeClient.Get(ctx, req.NamespacedName, current))
+	require.Len(t, current.Status.AppliedResources, 7, "all resources should be tracked")
+
+	// Then they are in a deterministic (sorted) order
+	assert.True(t, sort.StringsAreSorted(current.Status.AppliedResources),
+		"appliedResources must be sorted; unsorted map iteration re-randomizes it every reconcile: %v",
+		current.Status.AppliedResources)
+}

--- a/internal/graph/dependency.go
+++ b/internal/graph/dependency.go
@@ -18,6 +18,7 @@ package graph
 
 import (
 	"fmt"
+	"sort"
 
 	lynqv1 "github.com/k8s-lynq/lynq/api/v1"
 )
@@ -130,10 +131,23 @@ func (g *DependencyGraph) TopologicalSort() ([]*Node, error) {
 	var result []*Node
 	processed := make(map[string]bool)
 
+	// Iterate IDs in a stable order. g.Nodes is a map and Go randomizes map iteration,
+	// so without this the order of resources *within* a level varies between calls. That
+	// leaks out through LynqNode.Status.SkippedResourceIds, whose reordering is a real
+	// etcd write that re-triggers reconciliation (see the appliedResources sort in
+	// reconcileSpec for the same failure mode). Dependency ordering *between* levels is
+	// unaffected — only the arbitrary intra-level order becomes deterministic.
+	ids := make([]string, 0, len(g.Nodes))
+	for id := range g.Nodes {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
 	// Process nodes level by level
 	maxLevel := g.getMaxLevel()
 	for level := 0; level <= maxLevel; level++ {
-		for _, node := range g.Nodes {
+		for _, id := range ids {
+			node := g.Nodes[id]
 			if node.Level == level && !processed[node.ID] {
 				result = append(result, node)
 				processed[node.ID] = true

--- a/internal/graph/dependency_behavior_test.go
+++ b/internal/graph/dependency_behavior_test.go
@@ -543,3 +543,83 @@ var _ = Describe("Dependency Graph - Core Behaviors", func() {
 		})
 	})
 })
+
+var _ = Describe("Dependency Graph - Ordering Stability", func() {
+	Context("Sorting the same resources more than once", func() {
+		Describe("Resources that share a dependency level", func() {
+			It("Should return the same order every time", func() {
+				By("Given several resources with no dependencies between them")
+				// Nodes are held in a map, and Go randomizes map iteration order. Resources
+				// on the same level have no dependency constraint to impose an order, so an
+				// unstable iteration leaks straight into the sorted result — and from there
+				// into LynqNode.Status.SkippedResourceIds, whose reordering is a real write
+				// that re-triggers reconciliation.
+				resources := []lynqv1.TResource{
+					{ID: "zeta"}, {ID: "alpha"}, {ID: "mike"}, {ID: "delta"},
+					{ID: "bravo"}, {ID: "yankee"}, {ID: "charlie"}, {ID: "oscar"},
+				}
+
+				By("When the graph is built and sorted repeatedly")
+				orderOf := func() []string {
+					g, err := BuildGraph(resources)
+					Expect(err).ToNot(HaveOccurred())
+
+					sorted, err := g.TopologicalSort()
+					Expect(err).ToNot(HaveOccurred())
+
+					ids := make([]string, 0, len(sorted))
+					for _, node := range sorted {
+						ids = append(ids, node.ID)
+					}
+					return ids
+				}
+
+				first := orderOf()
+
+				By("Then every subsequent sort produces an identical order")
+				for i := 0; i < 20; i++ {
+					Expect(orderOf()).To(Equal(first),
+						"TopologicalSort must be deterministic across calls")
+				}
+			})
+		})
+
+		Describe("Resources with dependencies", func() {
+			It("Should keep dependency ordering while remaining deterministic", func() {
+				By("Given a diamond dependency: base <- left, right <- top")
+				resources := []lynqv1.TResource{
+					{ID: "top", DependIds: []string{"left", "right"}},
+					{ID: "right", DependIds: []string{"base"}},
+					{ID: "left", DependIds: []string{"base"}},
+					{ID: "base"},
+				}
+
+				By("When the graph is sorted repeatedly")
+				var first []string
+				for i := 0; i < 20; i++ {
+					g, err := BuildGraph(resources)
+					Expect(err).ToNot(HaveOccurred())
+
+					sorted, err := g.TopologicalSort()
+					Expect(err).ToNot(HaveOccurred())
+
+					ids := make([]string, 0, len(sorted))
+					for _, node := range sorted {
+						ids = append(ids, node.ID)
+					}
+
+					By("Then dependencies still precede their dependents")
+					Expect(ids[0]).To(Equal("base"))
+					Expect(ids[3]).To(Equal("top"))
+
+					if first == nil {
+						first = ids
+						continue
+					}
+					By("And the order is identical to the previous sort")
+					Expect(ids).To(Equal(first))
+				}
+			})
+		})
+	})
+})

--- a/internal/status/manager.go
+++ b/internal/status/manager.go
@@ -19,6 +19,7 @@ package status
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 	"time"
 
@@ -274,45 +275,53 @@ func (m *Manager) applyUpdate(ctx context.Context, update *StatusUpdate) error {
 			return err
 		}
 
-		// Apply changes to status
+		// Apply changes to status.
+		//
+		// Every field below is compared against the value already on the object before
+		// being marked as changed. A published field is a *candidate* value, not proof
+		// that anything differs: reconcileSpec/reconcileStatus republish the full set on
+		// every pass, so treating "published" as "changed" issues a Status().Update() on
+		// every reconcile. Each such write bumps resourceVersion, fires a LynqNode watch
+		// event, and re-enqueues the node — a self-sustaining reconcile loop. Comparing
+		// values keeps the write (and the event) for genuine transitions only.
 		statusChanged := false
 
-		if update.ObservedGeneration != nil {
+		if update.ObservedGeneration != nil && node.Status.ObservedGeneration != *update.ObservedGeneration {
 			node.Status.ObservedGeneration = *update.ObservedGeneration
 			statusChanged = true
 		}
 
-		if update.ReadyResources != nil {
+		if update.ReadyResources != nil && node.Status.ReadyResources != *update.ReadyResources {
 			node.Status.ReadyResources = *update.ReadyResources
 			statusChanged = true
 		}
 
-		if update.FailedResources != nil {
+		if update.FailedResources != nil && node.Status.FailedResources != *update.FailedResources {
 			node.Status.FailedResources = *update.FailedResources
 			statusChanged = true
 		}
 
-		if update.DesiredResources != nil {
+		if update.DesiredResources != nil && node.Status.DesiredResources != *update.DesiredResources {
 			node.Status.DesiredResources = *update.DesiredResources
 			statusChanged = true
 		}
 
-		if update.AppliedResources != nil {
+		if update.AppliedResources != nil && !slices.Equal(node.Status.AppliedResources, update.AppliedResources) {
 			node.Status.AppliedResources = update.AppliedResources
 			statusChanged = true
 		}
 
-		if update.SkippedResources != nil {
+		if update.SkippedResources != nil && node.Status.SkippedResources != *update.SkippedResources {
 			node.Status.SkippedResources = *update.SkippedResources
 			statusChanged = true
 		}
 
-		if update.SkippedResourceIds != nil {
+		if update.SkippedResourceIds != nil && !slices.Equal(node.Status.SkippedResourceIds, update.SkippedResourceIds) {
 			node.Status.SkippedResourceIds = update.SkippedResourceIds
 			statusChanged = true
 		}
 
-		if update.LastFullReconcileAt != nil {
+		if update.LastFullReconcileAt != nil && !node.Status.LastFullReconcileAt.Equal(update.LastFullReconcileAt) {
 			node.Status.LastFullReconcileAt = update.LastFullReconcileAt
 			statusChanged = true
 		}

--- a/internal/status/manager_test.go
+++ b/internal/status/manager_test.go
@@ -440,3 +440,107 @@ func TestNewStatusUpdate(t *testing.T) {
 	assert.Nil(t, update.ReadyResources)
 	assert.Nil(t, update.FailedResources)
 }
+
+// TestManager_NoWriteWhenValuesUnchanged verifies that republishing identical status values
+// does not issue an API write.
+//
+// Reconcilers republish their full status on every pass, so "a field was published" is not
+// evidence that anything changed. Treating it as such issued a Status().Update() on every
+// reconcile; each write bumps resourceVersion, fires a LynqNode watch event, and re-enqueues
+// the node, which sustained a full-reconcile loop in production.
+func TestManager_NoWriteWhenValuesUnchanged(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	require.NoError(t, lynqv1.AddToScheme(scheme))
+
+	node := &lynqv1.LynqNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-node", Namespace: "default"},
+		Spec:       lynqv1.LynqNodeSpec{UID: "node1"},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(node).
+		WithStatusSubresource(node).
+		Build()
+
+	m := NewManager(fakeClient, WithSyncMode())
+	key := types.NamespacedName{Name: node.Name, Namespace: node.Namespace}
+
+	resourceVersion := func() string {
+		current := &lynqv1.LynqNode{}
+		require.NoError(t, fakeClient.Get(ctx, key, current))
+		return current.ResourceVersion
+	}
+
+	publishAll := func() {
+		m.PublishObservedGeneration(node, 1)
+		m.PublishResourceCounts(node, 3, 0, 3, 0)
+		m.PublishAppliedResources(node, []string{"ConfigMap/default/a@a", "Secret/default/b@b"})
+		m.PublishSkippedResources(node, 0, nil)
+		m.PublishReadyCondition(node, true, "Reconciled", "Successfully reconciled all resources")
+	}
+
+	// Given a node whose status has been published once
+	publishAll()
+	settled := resourceVersion()
+	assert.NotEqual(t, node.ResourceVersion, settled, "the first publish should write")
+
+	// When the identical status is published again, repeatedly
+	for i := 0; i < 5; i++ {
+		publishAll()
+	}
+
+	// Then no further writes occur
+	assert.Equal(t, settled, resourceVersion(),
+		"republishing unchanged status wrote to the API server")
+}
+
+// TestManager_WritesWhenValueActuallyChanges guards the other direction: the equality checks
+// must not suppress genuine transitions.
+func TestManager_WritesWhenValueActuallyChanges(t *testing.T) {
+	ctx := context.Background()
+	scheme := runtime.NewScheme()
+	require.NoError(t, lynqv1.AddToScheme(scheme))
+
+	node := &lynqv1.LynqNode{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-node", Namespace: "default"},
+		Spec:       lynqv1.LynqNodeSpec{UID: "node1"},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(node).
+		WithStatusSubresource(node).
+		Build()
+
+	m := NewManager(fakeClient, WithSyncMode())
+	key := types.NamespacedName{Name: node.Name, Namespace: node.Namespace}
+
+	read := func() *lynqv1.LynqNode {
+		current := &lynqv1.LynqNode{}
+		require.NoError(t, fakeClient.Get(ctx, key, current))
+		return current
+	}
+
+	// Given a settled status
+	m.PublishResourceCounts(node, 3, 0, 3, 0)
+	m.PublishAppliedResources(node, []string{"ConfigMap/default/a@a"})
+	settled := read()
+
+	// When a resource starts failing
+	m.PublishResourceCounts(node, 2, 1, 3, 0)
+
+	// Then the change is persisted
+	afterCounts := read()
+	assert.NotEqual(t, settled.ResourceVersion, afterCounts.ResourceVersion, "changed counts should write")
+	assert.Equal(t, int32(1), afterCounts.Status.FailedResources)
+	assert.Equal(t, int32(2), afterCounts.Status.ReadyResources)
+
+	// And when the tracked resource set changes
+	m.PublishAppliedResources(node, []string{"ConfigMap/default/a@a", "Secret/default/b@b"})
+
+	afterApplied := read()
+	assert.NotEqual(t, afterCounts.ResourceVersion, afterApplied.ResourceVersion, "changed applied set should write")
+	assert.Len(t, afterApplied.Status.AppliedResources, 2)
+}

--- a/internal/template/engine.go
+++ b/internal/template/engine.go
@@ -61,6 +61,24 @@ type Engine struct {
 	funcMap template.FuncMap
 }
 
+// sharedEngine is the process-wide Engine returned by SharedEngine.
+var sharedEngine = sync.OnceValue(NewEngine)
+
+// SharedEngine returns a process-wide Engine.
+//
+// An Engine is immutable after construction — its funcMap is never written to again — and
+// Render is safe for concurrent use (the parsed-template cache is a sync.Map and
+// template.Template.Execute is concurrency-safe after parsing). Every Engine built by
+// NewEngine is therefore interchangeable.
+//
+// Prefer this over NewEngine on any per-item path: NewEngine calls sprig.TxtFuncMap(), which
+// allocates and populates a fresh ~200-entry map on every call. The hub previously built one
+// Engine per LynqNode create/update, so a rollout across N nodes allocated N such maps for no
+// benefit.
+func SharedEngine() *Engine {
+	return sharedEngine()
+}
+
 // NewEngine creates a new template engine with all functions
 func NewEngine() *Engine {
 	engine := &Engine{


### PR DESCRIPTION
## Description

On a production deployment the controller-manager was pinned at roughly **2.7× its CPU request**
while the cluster was completely idle — every LynqNode Ready, zero failed resources. Read-only
inspection showed the operator rewriting **a majority of its LynqNodes every 60 seconds** with
nothing in the cluster changing.

The cause was a self-sustaining full-reconcile loop. Diffing a single LynqNode across two
consecutive writes showed exactly one semantic change — the *order* of `status.appliedResources`:

```diff
   "KafkaTopic/<ns>/<uid>-internal-event@kafka-internal-event",
-  "KafkaTopic/<ns>/<uid>-dlq@kafka-dlq",
   "KafkaTopic/<ns>/<uid>-external-event@kafka-external-event",
+  "KafkaTopic/<ns>/<uid>-dlq@kafka-dlq",
```

The slice is assembled by ranging over a map, and Go randomizes map iteration. The API server only
elides an update when the serialized object is byte-identical, so a reordered slice is a real etcd
write → `resourceVersion` bump → LynqNode watch event → another reconcile → another reordering.
Since `determineReconcileType` always returns `ReconcileTypeSpec`, every one of those events cost a
full render / DAG / apply pass.

The churn rate tracked the probability that a random permutation differs from the previous one
(`1 - 1/k!`) almost exactly, which confirms the mechanism. Grouping the nodes by how many resources
each LynqForm produces:

| resources per node (`k`) | nodes rewritten in 60s | `1 - 1/k!` |
|---|---|---|
| 1 | ~17% ¹ | 0% |
| 3 | ~53% | 83% |
| 7 | **~97%** | 99.98% |

¹ Not ordering churn — this is the legitimate 10-minute force-reapply writing `lastFullReconcileAt`,
which works out to ~10% of nodes per minute. With a single element the order cannot change, exactly
as predicted.

This PR is Step 1 of a larger effort: the behavior-preserving fixes only. Findings that need a
design decision (informer cache scoping, restoring the dead `ReconcileTypeStatus` path, adaptive
requeue) are deliberately out of scope and listed under Additional Notes.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [x] Test improvement

## Related Issues

<!-- No tracking issue; found during a production CPU investigation. -->

## Changes Made

**`fix(lynqnode): break self-sustaining reconcile loop`**

- Sort `status.appliedResources` before publishing it. Order was never observable — the field is
  consumed as a set by `findOrphanedResources` and parsed per-element by `parseAppliedResource`.
- Make `TopologicalSort` deterministic. It iterates the node map, leaking the same instability into
  `status.skippedResourceIds` and into the apply order. Only the arbitrary *intra-level* order
  becomes fixed; dependency ordering between levels is untouched.
- Compare each status field against its stored value in `StatusManager.applyUpdate` before marking
  the update dirty. Reconcilers republish their full status every pass, so "a field was published"
  was never evidence that anything changed.
- Throttle the mid-loop LynqNode deletion probe to 250ms. It re-read the whole CR once per resource
  to check one timestamp, and the cached client returns a DeepCopy of an object that embeds every
  resolved resource spec — tens of KB for a non-trivial LynqForm.

**`perf(lynqhub): hoist rollout skew count out of desired-set loop`**

- `canUpdateNodeWithCount` called `countUpdatingNodes` once per desired node; each call rescans every
  node for the template and issues a cached workload GET (plus DeepCopy) per applied resource. With
  `maxSkew` configured, that is `O(templates × rows²)` per sync — tens of thousands of scans on every
  sync interval at a few hundred nodes.
- The count depends only on `(templateNodes, tmpl.Generation)`, both fixed snapshots within one
  Reconcile, and in-loop updates are already tracked by `updatedInThisIteration` — so memoizing per
  template preserves `maxSkew` semantics exactly.

**`perf(template): share the engine instead of rebuilding sprig FuncMap`**

- The hub built a fresh `Engine` per LynqNode create/update; `NewEngine` calls `sprig.TxtFuncMap()`,
  which allocates a ~200-entry map every time. An `Engine` is immutable after construction and
  `Render` is concurrency-safe, so all instances are interchangeable.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] All tests passing (`make test`)
- [x] Manual testing performed

New regression tests assert the invariant directly rather than the implementation, so they also
cover any future field that reintroduces the same class of instability:

| Test | Asserts |
|---|---|
| `TestRegression_SteadyStateReconcileDoesNotWriteStatus` | repeated reconciles of an unchanged node never write |
| `TestRegression_AppliedResourcesIsSorted` | the published slice is in deterministic order |
| `TestManager_NoWriteWhenValuesUnchanged` | republishing identical status issues no API call |
| `TestManager_WritesWhenValueActuallyChanges` | equality checks do not suppress real transitions |
| `Dependency Graph - Ordering Stability` (Ginkgo) | `TopologicalSort` is stable across calls, dependency order preserved |

All of them were verified to **fail on the parent commit** — the steady-state test caught 4 writes
per reconcile — and to pass here.

**Status of local verification:** `make lint` passes with 0 issues and `go build ./...` succeeds.
`go test ./internal/... ./api/...` passed for every package, but that run predates the final
`rolloutSkewCounter` extraction (done to keep `Reconcile` under the gocyclo limit); that last
refactor was covered locally by lint + build only. **CI is the source of truth for this PR.**

Manual testing was read-only inspection of a running deployment; no test touched it (envtest runs
against local `bin/k8s` binaries and `UseExistingCluster` is unset).

**Test Coverage:** not measured for this change.

## Documentation

- [ ] Documentation updated (if needed)
- [ ] API changes documented
- [ ] Examples added/updated (if needed)
- [ ] CHANGELOG.md updated (for significant changes)

No user-facing surface changed — no CRD fields, no flags, no status semantics. `CLAUDE.md` documents
the reconcile invariants and may be worth a follow-up note about the ordering requirement.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [ ] I have updated the documentation accordingly
- [x] My changes maintain backward compatibility (or breaking changes are documented)

## Screenshots / Logs

Measured read-only before any change, on an idle cluster with 0 failed and 0 not-Ready nodes:

```
# manager CPU: leader ~2.7x its configured cpu request; standby ~0
# LynqNode resourceVersion delta over 60s:
#   ~55% of all managed LynqNodes were rewritten
#   grouped by resources-per-node: k=7 -> ~97%, k=3 -> ~53%, k=1 -> ~17%
```

## Additional Notes

**Behavior change to flag explicitly.** Everything here is behavior-preserving except one detail:
the mid-loop deletion probe now runs on a 250ms interval instead of once per resource. The loop body
never blocks — readiness is sampled, never waited on — so detection latency is unchanged in
wall-clock terms, but the check no longer happens between every single resource. Happy to revert
this hunk if the stricter guarantee is preferred.

**Deliberately out of scope**, pending measurement of what this PR actually recovers:

1. `determineReconcileType` unconditionally returns `ReconcileTypeSpec`, making `ReconcileTypeStatus`
   and `reconcileStatus`'s 5-minute requeue dead code. The comment explaining why is correct —
   annotation changes don't bump `metadata.generation` — so restoring it needs a variable-annotation
   fingerprint in status, not a one-line change.
2. All 14 child kinds are registered on **both** `Owns()` and `Watches()`, so every cluster event
   runs the same predicate twice.
3. The manager caches every object of each watched kind cluster-wide with no selector. On the cluster
   examined, that was several times more objects than Lynq actually manages. Scoping it requires
   labelling all managed resources, not just cross-namespace ones.
4. Every `*unstructured.Unstructured` read bypasses the cache — controller-runtime's
   `cacheUnstructured` defaults to false and no client options are set — so each resource costs two
   live API round trips per reconcile (one in `ApplyResource`, one for the readiness check). The
   second is removable by returning the object `ApplyResource` already fetched.

## Self review

- [ ] Claude
- [ ] Codex
