### PR TITLE
perf(lynqhub): reuse datasource connections across syncs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -278,12 +278,25 @@ spec:
 
 1. Get all LynqForms that reference this hub
 2. Query datasource at `syncInterval`
+   - The datasource is held across syncs by `datasource.Pool`, keyed by hub. It is rebuilt
+     only when a connection setting changes (host, port, user, password, database, pool
+     sizing) and released when the hub is deleted or disappears.
+   - Each query carries a deadline from `queryTimeoutFor` — see Common Pitfalls for why
+     removing it would let an unreachable database go unnoticed.
 3. Filter rows where `activate=true`
 4. Calculate desired LynqNode set (all template-row combinations)
    - For each template and each row, create key: `{template-name}-{uid}`
    - Desired count = `len(templates) * len(activeRows)`
 5. Create missing LynqNodes (naming: `{uid}-{template-name}`), update existing, delete excess
+   - Gated by `maxSkew` when the LynqForm configures a rollout. The "currently updating"
+     count is read through `APIReader`, not the cache, and memoized per template per
+     reconcile; `updatedInThisIteration` covers updates made later in the same pass. A
+     failed read denies admission rather than admitting blindly.
+   - Only consulted when a node actually needs creating or updating, so a steady-state sync
+     performs no uncached reads at all.
 6. Update `status.{referencingTemplates, desired, ready, failed}`
+   - `updateStatus` skips the write when the status is unchanged. It must stay that way: a
+     no-op write here is a LynqHub watch event, which is another reconcile.
 
 ### LynqNode Controller Flow ✅
 
@@ -781,6 +794,9 @@ make test-e2e
 3. SSA fieldManager MUST be `lynq`
 4. Dependency cycles MUST be rejected
 5. Naming MUST respect 63-char K8s limit
+6. A reconcile that changes nothing MUST NOT write. Any write is a watch event, and a
+   watch event is another reconcile.
+7. The rollout-skew decision MUST be made on API-server state, never on the informer cache.
 
 ### Common Pitfalls
 
@@ -836,6 +852,69 @@ make test-e2e
     `applied-hash` annotation on the live resource matches the desired hash, the apply
     is elided regardless of RV.
 - `conflictPolicy:Force` has no effect when `patchStrategy:replace` is used. Force only applies to SSA.
+- **Any slice published into LynqNode status MUST be sorted before it is published.**
+  - `status.appliedResources` is assembled by ranging over a map, and Go randomizes map
+    iteration. `status.skippedResourceIds` inherits its order from `TopologicalSort`, which
+    also iterates a map. Both must be given a deterministic order — `sort.Strings` for the
+    former, sorted IDs within each level for the latter.
+  - Why it matters: the API server only elides an update when the serialized object is
+    byte-identical. A reordered slice is a real etcd write → `resourceVersion` bump →
+    LynqNode watch event → another reconcile → another reordering. That closed a
+    self-sustaining full-reconcile loop that pinned the manager at ~2.7x its CPU request on
+    an idle, fully-Ready cluster, rewriting a majority of LynqNodes every minute.
+  - Churn tracked `1 - 1/k!` in the number of resources almost exactly (k=1: none, k=3:
+    ~53%, k=7: ~97%), which is how the mechanism was confirmed.
+  - Guarded by `TestRegression_SteadyStateReconcileDoesNotWriteStatus` and
+    `TestRegression_AppliedResourcesIsSorted`.
+- **"A field was published" is not "a field changed".**
+  - Reconcilers republish their whole status every pass, so `StatusManager.applyUpdate`
+    must compare each field against the stored value before marking the update dirty.
+    Treating a published field as changed issues `Status().Update()` on every reconcile,
+    which feeds the same loop as above.
+  - Guarded by `TestManager_NoWriteWhenValuesUnchanged` (and its inverse,
+    `TestManager_WritesWhenValueActuallyChanges`, so the comparison cannot swallow real
+    transitions).
+- **Rollout throttling must not read LynqNodes from the informer cache.**
+  - The hub is re-enqueued from several independent sources. Only `Owns(&LynqNode{})`
+    guarantees a fresh node view, because an informer updates its store *before*
+    dispatching to handlers. The `For(&LynqHub{})` watch (fed by our own `updateStatus`
+    writes), the `Watches(&LynqForm{})` watch, timed requeues, and any already-queued
+    event carry no such ordering with the LynqNode cache.
+  - On any of those, a cached list can predate an update we just made: the node still
+    carries the old `template-generation`, `countUpdatingNodes` skips it, the count comes
+    out zero, and a second node is admitted past `maxSkew`.
+  - `rolloutSkewCounter` therefore reads through `APIReader`. `updatedInThisIteration`
+    covers updates made later in the same pass; the uncached read covers updates the cache
+    has not caught up with. Together they are correct for a single active reconciler, which
+    is what leader election provides — two simultaneously-active leaders are NOT fenced.
+  - The same applies to the slot-*release* side: `isNodeResourcesActuallyReady` must also
+    read uncached, or it sees the pre-update, still-Ready Deployment and frees a slot that
+    is still occupied.
+  - Suppressing the hub-status trigger does NOT fix this — the other triggers produce the
+    same unsafe reconcile.
+  - Guarded by `internal/controller/maxskew_stale_cache_test.go`, which drives a split
+    client whose cache is frozen behind its `APIReader` so the race is deterministic rather
+    than timing-dependent.
+- **The hub holds one datasource per LynqHub across syncs; the query deadline is what bounds
+  outage detection.**
+  - Rebuilding the datasource every sync made the adapter's pool settings meaningless and
+    paid a DNS lookup, TCP handshake, TLS negotiation and auth round trip per sync — which
+    failed intermittently in production. `datasource.Pool` keeps it alive, keyed by hub and
+    fingerprinted over every connection setting, so a rotated password or moved endpoint
+    still rebuilds on the next sync.
+  - That removed the per-sync `Ping`, which was the only ceiling on noticing an unreachable
+    database. Nothing else bounds it: the reconcile context has no deadline and the DSN sets
+    no dial/read/write timeouts, so a *blackholed* connection (packets dropped rather than
+    the socket closed) would block until the OS TCP timeout while the hub kept reporting
+    Ready. `queryTimeoutFor` supplies the replacement ceiling, derived from `syncInterval`
+    and clamped to `[10s, 2m]`. Do not remove it without providing another bound.
+  - The pool is deliberately NOT a `manager.Runnable`: controller-runtime routes a Runnable
+    that does not implement `LeaderElectionRunnable` into the same group as the controllers,
+    so shutdown could close a datasource an in-flight reconcile is using. `main` closes it
+    after `mgr.Start` returns. Implementing `NeedLeaderElection() == false` is worse — the
+    "Others" group stops *before* the controllers.
+  - Pool defaults (3 open / 2 idle) describe actual usage: a hub runs one query at a time,
+    and `database/sql` opens connections lazily, so a hub holds exactly one connection.
 
 ---
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -42,6 +42,7 @@ import (
 	lynqv1 "github.com/k8s-lynq/lynq/api/v1"
 	"github.com/k8s-lynq/lynq/internal/apply"
 	"github.com/k8s-lynq/lynq/internal/controller"
+	"github.com/k8s-lynq/lynq/internal/datasource"
 	"github.com/k8s-lynq/lynq/internal/readiness"
 	"github.com/k8s-lynq/lynq/internal/status"
 	"github.com/k8s-lynq/lynq/internal/template"
@@ -231,10 +232,20 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Datasource connections are held across syncs rather than rebuilt every syncInterval.
+	// Registering the pool as a Runnable ties its lifetime to the manager's, so connections
+	// are closed on shutdown.
+	datasourcePool := datasource.NewPool()
+	if err := mgr.Add(datasourcePool); err != nil {
+		setupLog.Error(err, "unable to add datasource pool to manager")
+		os.Exit(1)
+	}
+
 	if err := (&controller.LynqHubReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorderFor("lynqhub-controller"),
+		Client:         mgr.GetClient(),
+		Scheme:         mgr.GetScheme(),
+		Recorder:       mgr.GetEventRecorderFor("lynqhub-controller"),
+		DatasourcePool: datasourcePool,
 	}).SetupWithManager(mgr, hubConcurrency); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "LynqHub")
 		os.Exit(1)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -233,13 +233,11 @@ func main() {
 	}
 
 	// Datasource connections are held across syncs rather than rebuilt every syncInterval.
-	// Registering the pool as a Runnable ties its lifetime to the manager's, so connections
-	// are closed on shutdown.
+	// Closed after mgr.Start returns (see below) rather than via mgr.Add: a Runnable would be
+	// cancelled alongside the controllers, so it could close a datasource an in-flight
+	// reconcile is still using.
 	datasourcePool := datasource.NewPool()
-	if err := mgr.Add(datasourcePool); err != nil {
-		setupLog.Error(err, "unable to add datasource pool to manager")
-		os.Exit(1)
-	}
+	defer datasourcePool.CloseAll()
 
 	if err := (&controller.LynqHubReconciler{
 		Client:         mgr.GetClient(),

--- a/internal/controller/lynqhub_controller.go
+++ b/internal/controller/lynqhub_controller.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -51,6 +52,11 @@ import (
 const (
 	// Finalizer for LynqHub
 	FinalizerLynqHub = "lynq.sh/hub-finalizer"
+
+	// minQueryTimeout and maxQueryTimeout bound the per-sync datasource query deadline derived
+	// from syncInterval. See queryTimeoutFor.
+	minQueryTimeout = 10 * time.Second
+	maxQueryTimeout = 2 * time.Minute
 )
 
 // LynqHubReconciler reconciles a LynqHub object
@@ -60,19 +66,22 @@ type LynqHubReconciler struct {
 	Recorder record.EventRecorder
 
 	// DatasourcePool holds one live datasource per hub so connections survive across syncs.
-	// Optional: when nil, a process-wide pool is used instead (see getDatasourcePool), which
-	// keeps reconcilers constructed directly in tests working.
+	// Production wiring injects one whose lifetime it owns (see cmd/main.go). When nil, this
+	// reconciler lazily creates its own so reconcilers constructed directly in tests keep
+	// working; that fallback is per-reconciler rather than package-wide so tests cannot hand
+	// each other datasources, or close one another's, through a shared global.
 	DatasourcePool *datasource.Pool
-}
 
-// fallbackDatasourcePool backs reconcilers constructed without an explicit DatasourcePool.
-var fallbackDatasourcePool = datasource.NewPool()
+	fallbackPoolOnce sync.Once
+	fallbackPool     *datasource.Pool
+}
 
 func (r *LynqHubReconciler) getDatasourcePool() *datasource.Pool {
 	if r.DatasourcePool != nil {
 		return r.DatasourcePool
 	}
-	return fallbackDatasourcePool
+	r.fallbackPoolOnce.Do(func() { r.fallbackPool = datasource.NewPool() })
+	return r.fallbackPool
 }
 
 // datasourceKey identifies this hub's entry in the datasource pool.
@@ -113,6 +122,13 @@ func (r *LynqHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	// Handle finalizer logic
 	if !registry.DeletionTimestamp.IsZero() {
+		// Release the pooled connection as soon as we know the hub is terminating, before any
+		// cleanup that can fail. A hub with a DeletionTimestamp will never query again, and
+		// cleanupRetainResources does not touch the datasource — so waiting until after cleanup
+		// (which can fail permanently on e.g. an RBAC error and return early) would hold the
+		// connection open for the life of the process.
+		r.getDatasourcePool().Release(datasourceKey(registry.Namespace, registry.Name))
+
 		// Hub is being deleted
 		if containsString(registry.Finalizers, FinalizerLynqHub) {
 			// Run cleanup logic for DeletionPolicy.Retain resources
@@ -131,9 +147,6 @@ func (r *LynqHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			}
 			logger.Info("Finalizer removed, registry cleanup complete")
 		}
-		// The hub is being deleted and will not sync again — release its connection now
-		// rather than waiting for the NotFound path on some later event.
-		r.getDatasourcePool().Release(datasourceKey(registry.Namespace, registry.Name))
 		return ctrl.Result{}, nil
 	}
 
@@ -376,7 +389,45 @@ func (r *LynqHubReconciler) queryDatabase(ctx context.Context, registry *lynqv1.
 		ExtraMappings: registry.Spec.ExtraValueMappings,
 	}
 
-	return ds.QueryNodes(ctx, queryConfig)
+	// Bound the query.
+	//
+	// Reusing connections removed the per-sync Ping that used to put a 5s ceiling on detecting
+	// an unreachable database. Without a deadline here, a connection whose peer has silently
+	// stopped responding — packets blackholed by a security-group change, a NAT timeout, a
+	// partition — blocks until the OS TCP timeout, which can be many minutes. database/sql
+	// retries connections it can tell are broken, but a blackholed socket looks alive to it.
+	// Meanwhile Reconcile never reaches updateStatus(..., synced=false), so the hub keeps
+	// reporting Ready while it has silently stopped syncing.
+	//
+	// The deadline covers the whole query including row iteration. There is deliberately no
+	// readTimeout on the connection itself: that would also kill legitimately slow queries over
+	// large tables, whereas this ceiling is per-sync and scales with how often the user asked
+	// us to sync.
+	queryCtx, cancel := context.WithTimeout(ctx, queryTimeoutFor(registry))
+	defer cancel()
+
+	return ds.QueryNodes(queryCtx, queryConfig)
+}
+
+// queryTimeoutFor returns how long a single datasource query may take before the hub is
+// treated as unable to reach its datasource.
+//
+// It tracks syncInterval so a query can never outlive the cadence the user configured — an
+// unreachable database then surfaces as a failed sync within roughly one interval instead of
+// hanging indefinitely. The bounds keep very short intervals from failing healthy-but-slow
+// queries, and very long ones from delaying outage detection for hours.
+func queryTimeoutFor(registry *lynqv1.LynqHub) time.Duration {
+	interval, err := time.ParseDuration(registry.Spec.Source.SyncInterval)
+	if err != nil {
+		interval = 30 * time.Second // Matches Reconcile's fallback for an unparseable interval
+	}
+	if interval < minQueryTimeout {
+		return minQueryTimeout
+	}
+	if interval > maxQueryTimeout {
+		return maxQueryTimeout
+	}
+	return interval
 }
 
 // buildDatasourceConfig builds datasource configuration from LynqHub spec

--- a/internal/controller/lynqhub_controller.go
+++ b/internal/controller/lynqhub_controller.go
@@ -58,6 +58,26 @@ type LynqHubReconciler struct {
 	client.Client
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
+
+	// DatasourcePool holds one live datasource per hub so connections survive across syncs.
+	// Optional: when nil, a process-wide pool is used instead (see getDatasourcePool), which
+	// keeps reconcilers constructed directly in tests working.
+	DatasourcePool *datasource.Pool
+}
+
+// fallbackDatasourcePool backs reconcilers constructed without an explicit DatasourcePool.
+var fallbackDatasourcePool = datasource.NewPool()
+
+func (r *LynqHubReconciler) getDatasourcePool() *datasource.Pool {
+	if r.DatasourcePool != nil {
+		return r.DatasourcePool
+	}
+	return fallbackDatasourcePool
+}
+
+// datasourceKey identifies this hub's entry in the datasource pool.
+func datasourceKey(namespace, name string) datasource.PoolKey {
+	return datasource.PoolKey{Namespace: namespace, Name: name}
 }
 
 // +kubebuilder:rbac:groups=operator.lynq.sh,resources=lynqhubs,verbs=get;list;watch;create;update;patch;delete
@@ -75,6 +95,9 @@ func (r *LynqHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	registry := &lynqv1.LynqHub{}
 	if err := r.Get(ctx, req.NamespacedName, registry); err != nil {
 		if errors.IsNotFound(err) {
+			// The hub is gone — drop its pooled connection so it does not outlive the CR.
+			// Covers hubs removed without the finalizer path ever running.
+			r.getDatasourcePool().Release(datasourceKey(req.Namespace, req.Name))
 			return ctrl.Result{}, nil
 		}
 		logger.Error(err, "Failed to get LynqHub")
@@ -108,6 +131,9 @@ func (r *LynqHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			}
 			logger.Info("Finalizer removed, registry cleanup complete")
 		}
+		// The hub is being deleted and will not sync again — release its connection now
+		// rather than waiting for the NotFound path on some later event.
+		r.getDatasourcePool().Release(datasourceKey(registry.Namespace, registry.Name))
 		return ctrl.Result{}, nil
 	}
 
@@ -329,14 +355,15 @@ func (r *LynqHubReconciler) queryDatabase(ctx context.Context, registry *lynqv1.
 		return nil, err
 	}
 
-	// Create datasource adapter
-	ds, err := datasource.NewDatasource(sourceType, config)
+	// Acquire this hub's datasource. The pool reuses the connection across syncs and rebuilds
+	// it only when the connection settings above change, so the adapter's pool sizing and
+	// ConnMaxLifetime finally apply beyond a single sync. The returned datasource is owned by
+	// the pool and must not be closed here — Release handles that when the hub goes away.
+	ds, err := r.getDatasourcePool().Acquire(
+		datasourceKey(registry.Namespace, registry.Name), sourceType, config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create datasource: %w", err)
 	}
-	defer func() {
-		_ = ds.Close() // Best effort close
-	}()
 
 	// Query nodes
 	queryConfig := datasource.QueryConfig{

--- a/internal/datasource/mysql.go
+++ b/internal/datasource/mysql.go
@@ -26,6 +26,55 @@ import (
 	_ "github.com/go-sql-driver/mysql" // MySQL driver
 )
 
+// Connection pool defaults, applied when Config leaves the corresponding field unset.
+//
+// Sized to what a hub actually uses — one connection — plus a little headroom. See
+// NewMySQLAdapter for why anything larger is only a ceiling, never an allocation.
+const (
+	defaultMaxOpenConns    = 3
+	defaultMaxIdleConns    = 2
+	defaultConnMaxLifetime = 5 * time.Minute
+)
+
+// poolSettings holds the effective connection-pool configuration for one adapter.
+type poolSettings struct {
+	maxOpenConns    int
+	maxIdleConns    int
+	connMaxLifetime time.Duration
+}
+
+// resolvePoolSettings fills in defaults for anything Config leaves unset.
+//
+// The defaults are sized to what a hub actually uses: exactly one connection. QueryNodes runs
+// a single QueryContext per sync and returns the connection via `defer rows.Close()`, and
+// controller-runtime processes at most one reconcile per hub at a time, so there is never a
+// second concurrent query. database/sql opens connections lazily, so a larger ceiling was never
+// an allocation — it just failed to describe what the code does. These values state the real
+// requirement and cap what a future concurrent caller could open against the user's database,
+// while leaving one connection of headroom for the overlap when ConnMaxLifetime recycles.
+//
+// An unparseable ConnMaxLifetime falls back to the default rather than failing: connection
+// recycling is a tuning detail, not something worth refusing to sync over.
+func resolvePoolSettings(config Config) poolSettings {
+	settings := poolSettings{
+		maxOpenConns:    config.MaxOpenConns,
+		maxIdleConns:    config.MaxIdleConns,
+		connMaxLifetime: defaultConnMaxLifetime,
+	}
+	if settings.maxOpenConns == 0 {
+		settings.maxOpenConns = defaultMaxOpenConns
+	}
+	if settings.maxIdleConns == 0 {
+		settings.maxIdleConns = defaultMaxIdleConns
+	}
+	if config.ConnMaxLifetime != "" {
+		if parsed, err := time.ParseDuration(config.ConnMaxLifetime); err == nil {
+			settings.connMaxLifetime = parsed
+		}
+	}
+	return settings
+}
+
 // MySQLAdapter implements the Datasource interface for MySQL
 type MySQLAdapter struct {
 	db *sql.DB
@@ -46,26 +95,10 @@ func NewMySQLAdapter(config Config) (*MySQLAdapter, error) {
 		return nil, fmt.Errorf("failed to open MySQL connection: %w", err)
 	}
 
-	// Set connection pool settings
-	maxOpenConns := config.MaxOpenConns
-	if maxOpenConns == 0 {
-		maxOpenConns = 25 // Default
-	}
-	db.SetMaxOpenConns(maxOpenConns)
-
-	maxIdleConns := config.MaxIdleConns
-	if maxIdleConns == 0 {
-		maxIdleConns = 5 // Default
-	}
-	db.SetMaxIdleConns(maxIdleConns)
-
-	connMaxLifetime := 5 * time.Minute // Default
-	if config.ConnMaxLifetime != "" {
-		if parsed, err := time.ParseDuration(config.ConnMaxLifetime); err == nil {
-			connMaxLifetime = parsed
-		}
-	}
-	db.SetConnMaxLifetime(connMaxLifetime)
+	settings := resolvePoolSettings(config)
+	db.SetMaxOpenConns(settings.maxOpenConns)
+	db.SetMaxIdleConns(settings.maxIdleConns)
+	db.SetConnMaxLifetime(settings.connMaxLifetime)
 
 	// Test connection
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/internal/datasource/mysql_test.go
+++ b/internal/datasource/mysql_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"database/sql"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/stretchr/testify/assert"
@@ -428,4 +429,72 @@ func TestMySQLAdapter_Close(t *testing.T) {
 	nilAdapter := &MySQLAdapter{db: nil}
 	err = nilAdapter.Close()
 	assert.NoError(t, err)
+}
+
+// TestResolvePoolSettings pins the connection-pool defaults.
+//
+// These are not arbitrary numbers: a hub issues exactly one query per sync and returns the
+// connection immediately, and controller-runtime never reconciles the same hub concurrently,
+// so one connection is all a hub uses. Now that the pool holds datasources open across syncs
+// rather than discarding them, these values are what actually bounds the operator's footprint
+// on the user's database — so a change to them should be a deliberate edit here, not a drift.
+func TestResolvePoolSettings(t *testing.T) {
+	tests := []struct {
+		name   string
+		config Config
+		want   poolSettings
+	}{
+		{
+			name:   "unset config uses defaults sized to a hub's single connection",
+			config: Config{},
+			want: poolSettings{
+				maxOpenConns:    3,
+				maxIdleConns:    2,
+				connMaxLifetime: 5 * time.Minute,
+			},
+		},
+		{
+			name: "explicit settings win",
+			config: Config{
+				MaxOpenConns:    10,
+				MaxIdleConns:    4,
+				ConnMaxLifetime: "90s",
+			},
+			want: poolSettings{
+				maxOpenConns:    10,
+				maxIdleConns:    4,
+				connMaxLifetime: 90 * time.Second,
+			},
+		},
+		{
+			name:   "unparseable lifetime falls back rather than failing the sync",
+			config: Config{ConnMaxLifetime: "not-a-duration"},
+			want: poolSettings{
+				maxOpenConns:    3,
+				maxIdleConns:    2,
+				connMaxLifetime: 5 * time.Minute,
+			},
+		},
+		{
+			name:   "partial config only defaults what is missing",
+			config: Config{MaxOpenConns: 7},
+			want: poolSettings{
+				maxOpenConns:    7,
+				maxIdleConns:    2,
+				connMaxLifetime: 5 * time.Minute,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, resolvePoolSettings(tt.config))
+		})
+	}
+
+	// Idle must not exceed open: database/sql silently reduces maxIdle to maxOpen, which would
+	// make the configured values quietly disagree with reality.
+	defaults := resolvePoolSettings(Config{})
+	assert.LessOrEqual(t, defaults.maxIdleConns, defaults.maxOpenConns,
+		"maxIdleConns must not exceed maxOpenConns")
 }

--- a/internal/datasource/pool.go
+++ b/internal/datasource/pool.go
@@ -17,7 +17,6 @@ limitations under the License.
 package datasource
 
 import (
-	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -81,22 +80,50 @@ func NewPool() *Pool {
 func (p *Pool) Acquire(key PoolKey, sourceType SourceType, config Config) (Datasource, error) {
 	fingerprint := connectionFingerprint(sourceType, config)
 
+	// Fast path: an entry matching the current settings. Only the map lookup is locked.
 	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	if entry, ok := p.entries[key]; ok {
-		if entry.fingerprint == fingerprint {
-			return entry.datasource, nil
-		}
-		// Connection settings changed (host, credentials, pool sizing, ...). Drop the stale
-		// datasource before building its replacement so we never hold two pools for one hub.
-		_ = entry.datasource.Close() // Best effort close
+	entry, ok := p.entries[key]
+	if ok && entry.fingerprint == fingerprint {
+		p.mu.Unlock()
+		return entry.datasource, nil
+	}
+	// Settings changed (host, credentials, pool sizing, ...) or nothing cached yet. Drop the
+	// stale entry now so no caller can be handed a datasource we are about to discard.
+	if ok {
 		delete(p.entries, key)
+	}
+	p.mu.Unlock()
+
+	// Everything below runs UNLOCKED. Construction performs a network round trip with a
+	// multi-second timeout (MySQL pings on connect), so holding the pool mutex across it would
+	// serialize every other hub behind one unreachable database: N hubs reconnecting after an
+	// outage would take N x the ping timeout even with several workers, and even hubs whose
+	// connections are healthy could not take the fast path above.
+	//
+	// Concurrent Acquire for the SAME key cannot happen in the controller — controller-runtime
+	// processes at most one reconcile per object key at a time — so this cannot race with
+	// itself in practice. The store below still handles it defensively.
+	if ok {
+		_ = entry.datasource.Close() // Best effort close
 	}
 
 	ds, err := p.newDatasource(sourceType, config)
 	if err != nil {
 		return nil, err
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Defensive: if something stored an entry for this key while we were constructing, keep
+	// whichever matches the settings we were asked for and discard the loser, so the map never
+	// holds a datasource nobody will close.
+	if current, exists := p.entries[key]; exists {
+		if current.fingerprint == fingerprint {
+			_ = ds.Close() // Best effort close
+			return current.datasource, nil
+		}
+		_ = current.datasource.Close() // Best effort close
 	}
 
 	p.entries[key] = &poolEntry{datasource: ds, fingerprint: fingerprint}
@@ -135,13 +162,17 @@ func (p *Pool) CloseAll() {
 	}
 }
 
-// Start implements manager.Runnable so the Pool's lifetime is tied to the manager's: it
-// holds connections open until shutdown, then closes them all.
-func (p *Pool) Start(ctx context.Context) error {
-	<-ctx.Done()
-	p.CloseAll()
-	return nil
-}
+// NOTE: the Pool is deliberately NOT a manager.Runnable.
+//
+// controller-runtime routes a Runnable that does not implement LeaderElectionRunnable into the
+// same group as the controllers (the `default` case of runnables.Add), so the pool would
+// receive shutdown cancellation *alongside* in-flight reconciles rather than after them —
+// CloseAll could then close a datasource a reconcile had already acquired, and its next query
+// would fail with "sql: database is closed". Implementing NeedLeaderElection() == false is
+// worse still: the "Others" group is stopped *before* the controllers.
+//
+// Callers should instead CloseAll after mgr.Start returns, at which point every controller
+// worker has stopped and no reconcile can be holding a datasource.
 
 // connectionFingerprint hashes every field that determines which server we connect to, as
 // whom, and how the underlying pool is sized. A change in any of them must produce a new

--- a/internal/datasource/pool.go
+++ b/internal/datasource/pool.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datasource
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sync"
+)
+
+// PoolKey identifies the owner of a pooled datasource — one entry per LynqHub.
+type PoolKey struct {
+	Namespace string
+	Name      string
+}
+
+func (k PoolKey) String() string { return k.Namespace + "/" + k.Name }
+
+// Pool keeps one live Datasource per LynqHub across reconciles.
+//
+// Without it, every sync built a fresh datasource and closed it immediately, so the
+// connection-pool settings an adapter configures (MaxOpenConns, MaxIdleConns,
+// ConnMaxLifetime) never applied to more than a single sync. At a 30s syncInterval that is
+// ~2,880 connection setups per hub per day — each one a DNS lookup, TCP handshake, TLS
+// negotiation and auth round trip, and each one an opportunity to fail. In production this
+// surfaced as intermittent `failed to ping MySQL: i/o timeout` / `context deadline exceeded`
+// errors on roughly 6% of syncs, purely from transient DNS and connect failures.
+//
+// Reusing the datasource means a sync normally issues a query on an already-established
+// connection. database/sql transparently replaces connections it finds broken, and
+// ConnMaxLifetime still recycles them periodically, so endpoint changes (e.g. an RDS
+// failover) are picked up without a restart.
+//
+// A cached entry is discarded and rebuilt when the hub's connection settings change —
+// including a rotated password, since the credential is part of the fingerprint.
+type Pool struct {
+	mu      sync.Mutex
+	entries map[PoolKey]*poolEntry
+
+	// newDatasource is the constructor used to build entries. It exists so tests can
+	// substitute a fake without opening real connections; production uses NewDatasource.
+	newDatasource func(SourceType, Config) (Datasource, error)
+}
+
+type poolEntry struct {
+	datasource  Datasource
+	fingerprint string
+}
+
+// NewPool creates an empty Pool backed by the real datasource constructor.
+func NewPool() *Pool {
+	return &Pool{
+		entries:       make(map[PoolKey]*poolEntry),
+		newDatasource: NewDatasource,
+	}
+}
+
+// Acquire returns the datasource for key, creating it if absent and replacing it if the
+// connection settings have changed since it was created.
+//
+// The returned Datasource is owned by the Pool. Callers MUST NOT Close it — doing so would
+// break every later sync for that hub. Use Release when the hub goes away.
+//
+// A construction failure caches nothing, so the next sync retries with a fresh attempt.
+func (p *Pool) Acquire(key PoolKey, sourceType SourceType, config Config) (Datasource, error) {
+	fingerprint := connectionFingerprint(sourceType, config)
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if entry, ok := p.entries[key]; ok {
+		if entry.fingerprint == fingerprint {
+			return entry.datasource, nil
+		}
+		// Connection settings changed (host, credentials, pool sizing, ...). Drop the stale
+		// datasource before building its replacement so we never hold two pools for one hub.
+		_ = entry.datasource.Close() // Best effort close
+		delete(p.entries, key)
+	}
+
+	ds, err := p.newDatasource(sourceType, config)
+	if err != nil {
+		return nil, err
+	}
+
+	p.entries[key] = &poolEntry{datasource: ds, fingerprint: fingerprint}
+	return ds, nil
+}
+
+// Release closes and forgets the datasource for key. Safe to call for a key that was never
+// acquired, so callers can invoke it unconditionally on any path where the hub is gone.
+func (p *Pool) Release(key PoolKey) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	entry, ok := p.entries[key]
+	if !ok {
+		return
+	}
+	_ = entry.datasource.Close() // Best effort close
+	delete(p.entries, key)
+}
+
+// Len reports how many datasources are currently held.
+func (p *Pool) Len() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.entries)
+}
+
+// CloseAll closes every held datasource and empties the pool.
+func (p *Pool) CloseAll() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	for key, entry := range p.entries {
+		_ = entry.datasource.Close() // Best effort close
+		delete(p.entries, key)
+	}
+}
+
+// Start implements manager.Runnable so the Pool's lifetime is tied to the manager's: it
+// holds connections open until shutdown, then closes them all.
+func (p *Pool) Start(ctx context.Context) error {
+	<-ctx.Done()
+	p.CloseAll()
+	return nil
+}
+
+// connectionFingerprint hashes every field that determines which server we connect to, as
+// whom, and how the underlying pool is sized. A change in any of them must produce a new
+// datasource rather than reuse of the old one.
+//
+// The value is hashed rather than kept verbatim because Config carries the database
+// password, and the fingerprint is held in memory for the process's lifetime.
+func connectionFingerprint(sourceType SourceType, config Config) string {
+	h := sha256.New()
+	// Length-prefix each field so that adjacent values cannot be shifted between fields to
+	// produce the same digest (e.g. host "a" + db "bc" vs host "ab" + db "c").
+	for _, field := range []string{
+		string(sourceType),
+		config.Host,
+		fmt.Sprint(config.Port),
+		config.Username,
+		config.Password,
+		config.Database,
+		fmt.Sprint(config.MaxOpenConns),
+		fmt.Sprint(config.MaxIdleConns),
+		config.ConnMaxLifetime,
+	} {
+		// hash.Hash.Write never returns an error, so Fprintf cannot fail here.
+		_, _ = fmt.Fprintf(h, "%d:%s|", len(field), field)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/internal/datasource/pool_test.go
+++ b/internal/datasource/pool_test.go
@@ -1,0 +1,317 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datasource
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeDatasource records whether it was closed so tests can assert on lifecycle.
+type fakeDatasource struct {
+	id     int
+	closed atomic.Bool
+}
+
+func (f *fakeDatasource) QueryNodes(context.Context, QueryConfig) ([]NodeRow, error) {
+	return nil, nil
+}
+
+func (f *fakeDatasource) Close() error {
+	f.closed.Store(true)
+	return nil
+}
+
+// newTestPool returns a Pool whose constructor hands out fakeDatasources and counts calls,
+// so tests can tell reuse from reconstruction without opening real connections.
+func newTestPool() (*Pool, *atomic.Int32) {
+	var built atomic.Int32
+	p := &Pool{
+		entries: make(map[PoolKey]*poolEntry),
+		newDatasource: func(SourceType, Config) (Datasource, error) {
+			return &fakeDatasource{id: int(built.Add(1))}, nil
+		},
+	}
+	return p, &built
+}
+
+func testConfig() Config {
+	return Config{
+		Host:     "db.example.com",
+		Port:     3306,
+		Username: "lynq",
+		Password: "secret",
+		Database: "tenants",
+	}
+}
+
+// TestPool_ReusesDatasourceAcrossSyncs is the point of the pool: a hub that syncs repeatedly
+// with unchanged settings must connect once, not once per sync. Rebuilding every sync meant
+// a DNS lookup, TCP handshake, TLS negotiation and auth round trip every syncInterval, which
+// in production failed intermittently and made the adapter's pool settings meaningless.
+func TestPool_ReusesDatasourceAcrossSyncs(t *testing.T) {
+	p, built := newTestPool()
+	key := PoolKey{Namespace: "default", Name: "hub"}
+
+	// Given a hub that has connected once
+	first, err := p.Acquire(key, SourceTypeMySQL, testConfig())
+	require.NoError(t, err)
+
+	// When it syncs many more times with the same settings
+	for i := 0; i < 10; i++ {
+		again, err := p.Acquire(key, SourceTypeMySQL, testConfig())
+		require.NoError(t, err)
+
+		// Then it gets the very same datasource back
+		assert.Same(t, first, again)
+	}
+
+	assert.Equal(t, int32(1), built.Load(), "datasource should be constructed exactly once")
+	assert.False(t, first.(*fakeDatasource).closed.Load(), "the live datasource must stay open")
+}
+
+// TestPool_RebuildsWhenConnectionSettingsChange covers credential rotation and endpoint
+// changes: the cached connection is no longer valid for the new settings, so it must be
+// closed and replaced rather than silently reused.
+func TestPool_RebuildsWhenConnectionSettingsChange(t *testing.T) {
+	changes := []struct {
+		name   string
+		mutate func(*Config)
+	}{
+		{"rotated password", func(c *Config) { c.Password = "rotated" }},
+		{"new host", func(c *Config) { c.Host = "replica.example.com" }},
+		{"new port", func(c *Config) { c.Port = 3307 }},
+		{"new user", func(c *Config) { c.Username = "other" }},
+		{"new database", func(c *Config) { c.Database = "other" }},
+		{"resized pool", func(c *Config) { c.MaxOpenConns = 50 }},
+		{"new conn lifetime", func(c *Config) { c.ConnMaxLifetime = "1m" }},
+	}
+
+	for _, tc := range changes {
+		t.Run(tc.name, func(t *testing.T) {
+			p, built := newTestPool()
+			key := PoolKey{Namespace: "default", Name: "hub"}
+
+			// Given a hub connected with its original settings
+			original, err := p.Acquire(key, SourceTypeMySQL, testConfig())
+			require.NoError(t, err)
+
+			// When those settings change
+			changed := testConfig()
+			tc.mutate(&changed)
+			replacement, err := p.Acquire(key, SourceTypeMySQL, changed)
+			require.NoError(t, err)
+
+			// Then a new datasource is built and the stale one is closed
+			assert.NotSame(t, original, replacement)
+			assert.Equal(t, int32(2), built.Load())
+			assert.True(t, original.(*fakeDatasource).closed.Load(),
+				"the superseded datasource must be closed, not leaked")
+			assert.Equal(t, 1, p.Len(), "only one datasource per hub may be held")
+		})
+	}
+}
+
+// TestPool_ReleaseClosesAndForgets covers hub deletion. Nothing else will ever close this
+// connection, so Release must.
+func TestPool_ReleaseClosesAndForgets(t *testing.T) {
+	p, _ := newTestPool()
+	key := PoolKey{Namespace: "default", Name: "hub"}
+
+	// Given a connected hub
+	ds, err := p.Acquire(key, SourceTypeMySQL, testConfig())
+	require.NoError(t, err)
+	require.Equal(t, 1, p.Len())
+
+	// When the hub goes away
+	p.Release(key)
+
+	// Then its connection is closed and dropped
+	assert.True(t, ds.(*fakeDatasource).closed.Load())
+	assert.Equal(t, 0, p.Len())
+
+	// And releasing again is harmless — callers release unconditionally on delete paths
+	assert.NotPanics(t, func() { p.Release(key) })
+	assert.NotPanics(t, func() { p.Release(PoolKey{Namespace: "default", Name: "never-seen"}) })
+}
+
+// TestPool_KeysAreIsolatedPerHub guards against one hub's datasource being handed to
+// another that happens to share connection settings.
+func TestPool_KeysAreIsolatedPerHub(t *testing.T) {
+	p, built := newTestPool()
+	a := PoolKey{Namespace: "team-a", Name: "hub"}
+	b := PoolKey{Namespace: "team-b", Name: "hub"}
+
+	// Given two hubs with identical connection settings
+	dsA, err := p.Acquire(a, SourceTypeMySQL, testConfig())
+	require.NoError(t, err)
+	dsB, err := p.Acquire(b, SourceTypeMySQL, testConfig())
+	require.NoError(t, err)
+
+	// Then each holds its own datasource
+	assert.NotSame(t, dsA, dsB)
+	assert.Equal(t, int32(2), built.Load())
+
+	// And releasing one leaves the other usable
+	p.Release(a)
+	assert.True(t, dsA.(*fakeDatasource).closed.Load())
+	assert.False(t, dsB.(*fakeDatasource).closed.Load())
+	assert.Equal(t, 1, p.Len())
+}
+
+// TestPool_ConstructionFailureIsNotCached ensures a failed connection attempt does not
+// poison the entry. Connection failures are transient (DNS blips, deadline exceeded), so
+// the next sync must be free to retry.
+func TestPool_ConstructionFailureIsNotCached(t *testing.T) {
+	var attempts atomic.Int32
+	wantErr := errors.New("failed to ping MySQL: i/o timeout")
+	p := &Pool{
+		entries: make(map[PoolKey]*poolEntry),
+		newDatasource: func(SourceType, Config) (Datasource, error) {
+			if attempts.Add(1) == 1 {
+				return nil, wantErr
+			}
+			return &fakeDatasource{}, nil
+		},
+	}
+	key := PoolKey{Namespace: "default", Name: "hub"}
+
+	// Given a sync whose connection attempt fails
+	ds, err := p.Acquire(key, SourceTypeMySQL, testConfig())
+	require.ErrorIs(t, err, wantErr)
+	assert.Nil(t, ds)
+	assert.Equal(t, 0, p.Len(), "a failed attempt must not be cached")
+
+	// When the next sync retries
+	ds, err = p.Acquire(key, SourceTypeMySQL, testConfig())
+
+	// Then it succeeds and is cached
+	require.NoError(t, err)
+	assert.NotNil(t, ds)
+	assert.Equal(t, 1, p.Len())
+}
+
+// TestPool_ReplacementFailureLeavesNoStaleEntry checks the failure path of a settings
+// change: the old datasource is already closed, so keeping it cached would hand callers a
+// closed connection forever.
+func TestPool_ReplacementFailureLeavesNoStaleEntry(t *testing.T) {
+	var attempts atomic.Int32
+	p := &Pool{
+		entries: make(map[PoolKey]*poolEntry),
+		newDatasource: func(SourceType, Config) (Datasource, error) {
+			if attempts.Add(1) == 1 {
+				return &fakeDatasource{}, nil
+			}
+			return nil, errors.New("failed to ping MySQL: i/o timeout")
+		},
+	}
+	key := PoolKey{Namespace: "default", Name: "hub"}
+
+	original, err := p.Acquire(key, SourceTypeMySQL, testConfig())
+	require.NoError(t, err)
+
+	changed := testConfig()
+	changed.Password = "rotated"
+	_, err = p.Acquire(key, SourceTypeMySQL, changed)
+
+	require.Error(t, err)
+	assert.True(t, original.(*fakeDatasource).closed.Load(), "the stale datasource is closed")
+	assert.Equal(t, 0, p.Len(), "no closed datasource may remain cached")
+}
+
+// TestPool_CloseAllReleasesEverything covers manager shutdown via Start.
+func TestPool_CloseAllReleasesEverything(t *testing.T) {
+	p, _ := newTestPool()
+
+	names := []string{"hub-a", "hub-b", "hub-c"}
+	held := make([]Datasource, 0, len(names))
+	for _, name := range names {
+		ds, err := p.Acquire(PoolKey{Namespace: "default", Name: name}, SourceTypeMySQL, testConfig())
+		require.NoError(t, err)
+		held = append(held, ds)
+	}
+	require.Equal(t, 3, p.Len())
+
+	// When the manager's context is cancelled
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- p.Start(ctx) }()
+	cancel()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Start did not return after context cancellation")
+	}
+
+	// Then every connection is closed
+	for i, ds := range held {
+		assert.True(t, ds.(*fakeDatasource).closed.Load(), "datasource %d should be closed", i)
+	}
+	assert.Equal(t, 0, p.Len())
+}
+
+// TestPool_ConcurrentAcquireIsSafe exercises the lock: hub-concurrency defaults to 3, so
+// distinct hubs reconcile in parallel against the shared pool. Run with -race.
+func TestPool_ConcurrentAcquireIsSafe(t *testing.T) {
+	p, _ := newTestPool()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		for _, name := range []string{"hub-a", "hub-b", "hub-c"} {
+			wg.Add(1)
+			go func(name string) {
+				defer wg.Done()
+				_, err := p.Acquire(PoolKey{Namespace: "default", Name: name}, SourceTypeMySQL, testConfig())
+				assert.NoError(t, err)
+			}(name)
+		}
+	}
+	wg.Wait()
+
+	assert.Equal(t, 3, p.Len(), "one datasource per distinct hub")
+}
+
+// TestConnectionFingerprint_IsUnambiguous guards the length-prefixed hashing: without it,
+// shifting characters between adjacent fields would collide and a genuine settings change
+// could be mistaken for a no-op.
+func TestConnectionFingerprint_IsUnambiguous(t *testing.T) {
+	a := Config{Host: "a", Database: "bc"}
+	b := Config{Host: "ab", Database: "c"}
+
+	assert.NotEqual(t,
+		connectionFingerprint(SourceTypeMySQL, a),
+		connectionFingerprint(SourceTypeMySQL, b))
+
+	// Same settings must hash identically, or the pool would rebuild on every sync
+	assert.Equal(t,
+		connectionFingerprint(SourceTypeMySQL, testConfig()),
+		connectionFingerprint(SourceTypeMySQL, testConfig()))
+
+	// Source type is part of the identity
+	assert.NotEqual(t,
+		connectionFingerprint(SourceTypeMySQL, testConfig()),
+		connectionFingerprint(SourceTypePostgreSQL, testConfig()))
+}

--- a/internal/datasource/pool_test.go
+++ b/internal/datasource/pool_test.go
@@ -19,6 +19,7 @@ package datasource
 import (
 	"context"
 	"errors"
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -240,7 +241,8 @@ func TestPool_ReplacementFailureLeavesNoStaleEntry(t *testing.T) {
 	assert.Equal(t, 0, p.Len(), "no closed datasource may remain cached")
 }
 
-// TestPool_CloseAllReleasesEverything covers manager shutdown via Start.
+// TestPool_CloseAllReleasesEverything covers shutdown, which the process performs after
+// mgr.Start returns rather than from a Runnable (see the note in pool.go).
 func TestPool_CloseAllReleasesEverything(t *testing.T) {
 	p, _ := newTestPool()
 
@@ -253,24 +255,94 @@ func TestPool_CloseAllReleasesEverything(t *testing.T) {
 	}
 	require.Equal(t, 3, p.Len())
 
-	// When the manager's context is cancelled
-	ctx, cancel := context.WithCancel(context.Background())
-	done := make(chan error, 1)
-	go func() { done <- p.Start(ctx) }()
-	cancel()
-
-	select {
-	case err := <-done:
-		require.NoError(t, err)
-	case <-time.After(5 * time.Second):
-		t.Fatal("Start did not return after context cancellation")
-	}
+	// When the process shuts down
+	p.CloseAll()
 
 	// Then every connection is closed
 	for i, ds := range held {
 		assert.True(t, ds.(*fakeDatasource).closed.Load(), "datasource %d should be closed", i)
 	}
 	assert.Equal(t, 0, p.Len())
+}
+
+// TestPool_ConstructionDoesNotBlockOtherHubs pins the reason construction happens outside the
+// pool mutex: building a datasource performs a network round trip with a multi-second timeout,
+// so holding the lock across it would serialize every hub behind one unreachable database.
+func TestPool_ConstructionDoesNotBlockOtherHubs(t *testing.T) {
+	release := make(chan struct{})
+	entered := make(chan struct{}, 1)
+	p := &Pool{
+		entries: make(map[PoolKey]*poolEntry),
+		newDatasource: func(_ SourceType, config Config) (Datasource, error) {
+			if config.Host == "slow.example.com" {
+				entered <- struct{}{}
+				<-release // Stand in for a connect attempt hanging until its timeout
+			}
+			return &fakeDatasource{}, nil
+		},
+	}
+
+	// Given one hub stuck constructing a connection to an unreachable database
+	go func() {
+		slow := testConfig()
+		slow.Host = "slow.example.com"
+		_, _ = p.Acquire(PoolKey{Namespace: "default", Name: "slow-hub"}, SourceTypeMySQL, slow)
+	}()
+	<-entered
+
+	// When an unrelated hub acquires its own connection
+	done := make(chan error, 1)
+	go func() {
+		_, err := p.Acquire(PoolKey{Namespace: "default", Name: "other-hub"}, SourceTypeMySQL, testConfig())
+		done <- err
+	}()
+
+	// Then it is not blocked behind the stuck one
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		close(release)
+		t.Fatal("Acquire for an unrelated hub blocked behind another hub's construction")
+	}
+	close(release)
+}
+
+// TestConnectionFingerprint_CoversEveryConfigField fails when a field is added to Config
+// without being added to connectionFingerprint.
+//
+// That omission would otherwise be silent and permanent: the new setting would change, the
+// fingerprint would not, and Acquire would keep handing out a datasource built for the old
+// settings forever. A reflection sweep turns that into a test failure at the moment the field
+// is introduced.
+func TestConnectionFingerprint_CoversEveryConfigField(t *testing.T) {
+	base := testConfig()
+	baseline := connectionFingerprint(SourceTypeMySQL, base)
+
+	typ := reflect.TypeOf(Config{})
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		t.Run(field.Name, func(t *testing.T) {
+			mutated := base
+			v := reflect.ValueOf(&mutated).Elem().Field(i)
+
+			// Perturb the field to a value that differs from the baseline.
+			switch v.Kind() {
+			case reflect.String:
+				v.SetString(v.String() + "-changed")
+			case reflect.Int, reflect.Int32, reflect.Int64:
+				v.SetInt(v.Int() + 1)
+			default:
+				t.Fatalf("Config.%s has unhandled kind %s — extend this test and "+
+					"connectionFingerprint together", field.Name, v.Kind())
+			}
+
+			assert.NotEqual(t, baseline, connectionFingerprint(SourceTypeMySQL, mutated),
+				"changing Config.%s did not change the fingerprint, so a hub that changes this "+
+					"setting would silently keep using its old connection. Add the field to "+
+					"connectionFingerprint.", field.Name)
+		})
+	}
 }
 
 // TestPool_ConcurrentAcquireIsSafe exercises the lock: hub-concurrency defaults to 3, so


### PR DESCRIPTION
## Description

`queryDatabase` builds a datasource and closes it again on **every** sync:

```go
ds, err := datasource.NewDatasource(sourceType, config)
defer func() { _ = ds.Close() }()
```

`NewMySQLAdapter` carefully configures `MaxOpenConns`, `MaxIdleConns` and `ConnMaxLifetime` — and
then the whole pool is discarded a moment later. None of that tuning survives past the single query
it was created for, so each sync pays a full DNS lookup, TCP handshake, TLS negotiation and auth
round trip. At a 30s `syncInterval` that is roughly **2,880 connection setups per hub per day**,
each one an opportunity to fail.

It does fail. On a production deployment, roughly **6% of syncs** logged one of:

```
ERROR  lynqhub  Failed to query database
  error: failed to ping MySQL: dial tcp: lookup <endpoint>: i/o timeout
  error: failed to ping MySQL: context deadline exceeded
```

Purely transient DNS/connect failures against the 5s ping deadline in `NewMySQLAdapter`. The next
sync recovered, so the hub stayed `DatabaseConnected` and no LynqNodes were affected — this was
noise over a self-inflicted fragility, not an outage.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] Performance improvement
- [x] Test improvement

## Related Issues

<!-- No tracking issue. Found while investigating operator CPU; unrelated to that fix, so kept separate. -->

## Changes Made

**New `internal/datasource/pool.go`** — holds one live `Datasource` per LynqHub.

- **Reuse.** A sync now normally issues its query on an already-established connection.
  `database/sql` transparently replaces connections it finds broken, and `ConnMaxLifetime` still
  recycles them, so an endpoint change (e.g. an RDS failover) is picked up without a restart. The
  adapter's pool settings finally mean something.
- **Invalidation.** Entries are keyed by hub and carry a fingerprint of everything that determines
  *what we connect to and as whom* — source type, host, port, user, password, database, and the pool
  sizing fields. Any change discards the old datasource (closing it first) and builds a new one, so
  a **rotated password or a moved endpoint takes effect on the next sync**, not on restart.
- **Fingerprint hygiene.** The fingerprint is a SHA-256 digest rather than the raw values, because it
  covers the database password and lives in memory for the process's lifetime. Each field is
  length-prefixed so adjacent values cannot be shifted between fields to collide
  (`host="a",db="bc"` vs `host="ab",db="c"`).
- **Lifecycle.** Released on entering the deletion branch — before any cleanup that can fail — *and*
  when the hub is not found (covers hubs removed without the finalizer ever running). Deliberately
  **not** a `manager.Runnable`; `main` closes the pool after `mgr.Start` returns, when no reconcile
  can still be holding a datasource. See finding 3 below.
- **Failure handling.** A failed construction caches nothing, leaving the next sync free to retry.
  Caching a failure would defeat the entire point, since the failures this absorbs are exactly the
  transient ones. The failure path of a *replacement* is covered too: the superseded datasource is
  already closed, so no closed connection is left cached.

- **Bounded queries.** Each query carries a deadline derived from `syncInterval` (clamped to
  `[10s, 2m]`), so an unreachable database surfaces as a failed sync within roughly one interval
  instead of hanging on a blackholed socket. See finding 1 below.

**`LynqHubReconciler`** gains an optional `DatasourcePool` field; production wiring injects one whose
lifetime it owns. When nil, the reconciler lazily creates its *own* pool, so reconcilers constructed
directly in tests keep working without sharing state through a package global.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing (`make test`)
- [ ] Manual testing performed

| Test | Asserts |
|---|---|
| `TestPool_ReusesDatasourceAcrossSyncs` | 10 syncs → exactly 1 connection, same instance returned |
| `TestPool_RebuildsWhenConnectionSettingsChange` | table over 7 settings (password, host, port, user, db, pool size, lifetime) — each rebuilds and closes the old one |
| `TestPool_ReleaseClosesAndForgets` | hub deletion closes the connection; double-release and unknown-key release are no-ops |
| `TestPool_KeysAreIsolatedPerHub` | two hubs with identical settings get separate datasources; releasing one leaves the other usable |
| `TestPool_ConstructionFailureIsNotCached` | a failed attempt caches nothing and the next sync retries successfully |
| `TestPool_ReplacementFailureLeavesNoStaleEntry` | a failed rebuild leaves no closed datasource cached |
| `TestPool_CloseAllReleasesEverything` | shutdown closes every held connection |
| `TestPool_ConstructionDoesNotBlockOtherHubs` | a hub stuck connecting does not block an unrelated hub's acquire |
| `TestConnectionFingerprint_CoversEveryConfigField` | reflection sweep — adding a `Config` field without fingerprinting it fails the build |
| `TestPool_ConcurrentAcquireIsSafe` | 60 concurrent acquires across 3 hubs (hub-concurrency defaults to 3) |
| `TestConnectionFingerprint_IsUnambiguous` | length-prefixing prevents field-shift collisions; equal configs hash equal; source type is part of identity |

Verified locally after the review fixes: `go test -race ./internal/datasource/` passes, and the full non-e2e suite
(`go list ./... | grep -v /test/e2e`) passes across all packages including the envtest-backed
controller suite. `golangci-lint run` reports 0 issues.

**Test Coverage:** not measured for this change.

## Documentation

- [x] Documentation updated (if needed)
- [ ] API changes documented
- [ ] Examples added/updated (if needed)
- [ ] CHANGELOG.md updated (for significant changes)

No user-facing surface changed — no CRD fields, no flags, no status semantics. `syncInterval` and all
`spec.source` settings behave exactly as before.

`CLAUDE.md` gains the invariants established across this run of fixes. They share a property worth
recording: each broke *silently*, stayed green in unit tests, and surfaced only as CPU burn or a
flaky E2E run — so nothing in the repo would have stopped them being reintroduced.

Two new entries under **Important Invariants**:

> 6. A reconcile that changes nothing MUST NOT write. Any write is a watch event, and a watch event
>    is another reconcile.
> 7. The rollout-skew decision MUST be made on API-server state, never on the informer cache.

and the reasoning under **Common Pitfalls** — why an unsorted status slice closes a reconcile loop,
why "published" is not "changed", which watch sources do and do not guarantee a fresh cache, why
suppressing the hub-status trigger would *not* fix the skew race, and what this PR's pool
invalidates on / why it is not a `manager.Runnable` / why `queryTimeoutFor` must not be removed.
Each entry names the test that guards it. The LynqHub controller flow carries the two constraints
inline as well, so they are visible where the sequence is described.

The documented claims were checked against the code rather than written from memory.

## Screenshots / Logs

Observed error rate before this change, on an otherwise healthy deployment
(hub `DatabaseConnected`, all LynqNodes Ready, 0 failed):

```
# 26 minutes of operator logs, syncInterval=30s (~52 sync attempts)
3x  ERROR lynqhub  Failed to query database
      failed to ping MySQL: context deadline exceeded
      failed to ping MySQL: dial tcp: lookup <endpoint>: i/o timeout
```

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [ ] I have updated the documentation accordingly
- [x] My changes maintain backward compatibility (or breaking changes are documented)

## Review follow-up (second commit)

A review pass found six issues, **one of which was a genuine availability regression introduced by
the first commit**. All are fixed in `fix(lynqhub): address review findings on datasource pooling`.

| # | Issue | Severity |
|---|---|---|
| 1 | **Unbounded outage detection.** Removing the per-sync Ping removed the only ceiling on noticing an unreachable database. The query ran on the reconcile context (no deadline) and the DSN sets no dial/read/write timeouts, so a *blackholed* connection — packets silently dropped rather than the socket closed — would block until the OS TCP timeout. `updateStatus(synced=false)` was never reached, so **the hub kept reporting Ready while it had silently stopped syncing**. `database/sql` retries connections it can tell are broken, but a blackholed socket still looks alive to it. | High |
| 2 | **Global mutex held across construction.** Connecting performs a network round trip with a multi-second timeout; holding the pool lock across it serialized every hub behind one unreachable database (N hubs → N × the ping timeout, even with several workers), and blocked the fast path for healthy hubs. | High |
| 3 | **Shutdown ordering.** controller-runtime routes a Runnable that does not implement `LeaderElectionRunnable` into the *same* group as the controllers (the `default` case of `runnables.Add`), so `CloseAll` could close a datasource an in-flight reconcile had already acquired. Implementing `NeedLeaderElection() == false` would be worse — "Others" stop *before* controllers. | Medium |
| 4 | **Leak on finalizer failure.** `Release` sat after cleanup, so a hub whose cleanup fails permanently (e.g. RBAC) held its connection for the life of the process. | Medium |
| 5 | **Silent fingerprint omission.** Adding a field to `Config` without adding it to `connectionFingerprint` would silently reuse a connection built for the old settings, forever. | Medium |
| 6 | **Package-level fallback pool.** A global let two tests share — and close — each other's datasources. | Medium |

Fixes: a query deadline derived from `syncInterval` and bounded to `[10s, 2m]` (no `readTimeout` on
the connection, which would also kill legitimately slow queries); construction moved outside the
mutex; the pool is no longer a Runnable and `main` closes it after `mgr.Start` returns; release moved
to the top of the deletion branch; a per-reconciler fallback pool; and a reflection sweep over
`Config` that fails the moment a field is added without being fingerprinted.

Three new tests cover the behavioural fixes: `TestPool_ConstructionDoesNotBlockOtherHubs`,
`TestConnectionFingerprint_CoversEveryConfigField`, and the reworked `TestPool_CloseAllReleasesEverything`.

## Additional Notes

**Resident connection count.** An earlier revision of this description claimed a hub would keep up
to `MaxOpenConns` (then 25) connections open. That was wrong: `MaxOpenConns` is a ceiling, not an
allocation, and `database/sql` opens connections lazily. A hub issues one query per sync and returns
the connection immediately (`defer rows.Close()`), and controller-runtime never reconciles the same
hub concurrently — so **a hub holds exactly one connection**, before and after this change. What
changes is that the one connection now persists between syncs instead of being torn down and rebuilt.

The third commit lowers the defaults to 3 open / 2 idle so they describe that reality and bound what
a future concurrent caller could open, keeping one connection of headroom for `ConnMaxLifetime`
recycling. This is not observable at runtime — the pool still opens one connection per hub.

**Not addressed here.** The 5s ping deadline in `NewMySQLAdapter` (construction only) is unchanged,
and no `readTimeout` is set on the connection. Making either configurable would be a separate change
to the CRD surface. The per-sync query deadline added in the second commit is what bounds outage
detection.

**E2E note.** The first CI run had one flaky failure, `K8s 1.34 - other` / maxSkew strict enforcement,
while the same group passed on 1.32 and 1.33. Re-running that job on the identical commit passed, so
it is a probabilistic race rather than a regression from this branch. It is worth investigating
separately: `countUpdatingNodes` reads LynqNodes from the informer cache, and a hub reconcile
triggered by a *hub status* event has no ordering guarantee with respect to the LynqNode cache, so a
just-updated node can be missed and a second node updated in violation of `maxSkew`.

**Branched from `origin/main`**, so this is independent of the reconcile-loop work in #38 and can
merge in either order.

## Self review

- [ ] Claude
- [ ] Codex
