### PR TITLE
ci: assign via the REST API instead of a third-party action

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -11,9 +11,26 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-    - name: 'Auto-assign issue'
-      uses: pozil/auto-assign-issue@v1
-      with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          assignees: selenehyun
-          numOfAssignee: 1
+      # Assigns via the REST API rather than a third-party action.
+      #
+      # This previously used pozil/auto-assign-issue@v1. A floating major-version tag means the
+      # code that actually runs can change without any change here, and it did: runs began failing
+      # with "Couldn't find issue info in current context" on pull_request events, alongside a
+      # warning that numOfAssignee was not a valid input — while nothing in this repository had
+      # been touched. Pinning to a commit SHA would stop the drift but keeps a dependency whose
+      # only job here is assigning one fixed user.
+      #
+      # The issues endpoint covers pull requests too (every PR is an issue), so a single call
+      # handles both trigger types. Assigning someone already assigned is a no-op, and self-
+      # assignment is permitted — which is the normal case here.
+      - name: Assign default owner
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+          ASSIGNEE: selenehyun
+        run: |
+          gh api --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "repos/${REPO}/issues/${NUMBER}/assignees" \
+            -f "assignees[]=${ASSIGNEE}"


### PR DESCRIPTION
## Description

The Auto Assign workflow fails on every newly opened PR:

```
##[warning] Unexpected input(s) 'numOfAssignee', valid inputs are ['repo-token', 'assignees']
Error: Couldn't find issue info in current context
    at run (/home/runner/work/_actions/pozil/auto-assign-issue/v1/src/index.js:12:15)
```

Nothing in this repository changed. The workflow pins `pozil/auto-assign-issue@v1` — a **floating
major-version tag**, so the code that actually executes can change underneath us, and it did. The
warning is the giveaway: the resolved action no longer declared `numOfAssignee`, an input this
workflow passes. It ran green on every PR up to late May and then started failing on its own.

This is the failure mode the workflow was always exposed to; it just took until now to fire.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test improvement

## Related Issues

<!-- No tracking issue. Noticed while reviewing CI on #38 / #39. -->

## Changes Made

Replaced the action with a single `gh api` call.

Pinning to a commit SHA would stop the drift, but the action's entire job here is assigning one
fixed user — everything else it offers (teams, random N-of, reviewer assignment) is unused. Dropping
the dependency removes the drift *and* the supply-chain surface for what is one REST call.

```yaml
- name: Assign default owner
  env:
    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
    REPO: ${{ github.repository }}
    NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
    ASSIGNEE: selenehyun
  run: |
    gh api --method POST \
      -H "Accept: application/vnd.github+json" \
      "repos/${REPO}/issues/${NUMBER}/assignees" \
      -f "assignees[]=${ASSIGNEE}"
```

Details that make one call enough for both triggers:

- **Every PR is an issue**, so `/issues/{n}/assignees` serves `issues` and `pull_request` events
  alike; `github.event.issue.number || github.event.pull_request.number` picks whichever fired.
- **Idempotent** — assigning someone already assigned is a no-op, so re-runs are safe.
- **Self-assignment is permitted** by the API, which is the normal case in this repository. The old
  action needed an explicit `allowSelfAssign` flag for this.
- **Permissions unchanged** — the existing `issues: write` / `pull-requests: write` already cover it.

Behaviour is otherwise identical: on a newly opened issue or PR, `selenehyun` is assigned.

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] All tests passing (`make test`)
- [x] Manual testing performed

Not covered by the Go test suite — this is a workflow file. Verified:

- YAML parses, and resolves to the expected triggers (`issues`, `pull_request`) and a single `run` step.
- **Opening this PR is itself the test.** If the workflow is fixed, Auto Assign goes green here and
  `selenehyun` is assigned automatically; if not, it fails exactly as before. Please confirm the
  assignee before merging.

**Test Coverage:** n/a

## Documentation

- [ ] Documentation updated (if needed)
- [ ] API changes documented
- [ ] Examples added/updated (if needed)
- [ ] CHANGELOG.md updated (for significant changes)

No user-facing surface — CI only.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [ ] I have updated the documentation accordingly
- [x] My changes maintain backward compatibility (or breaking changes are documented)

## Additional Notes

**Worth considering separately:** other workflows in this repository also use floating tags
(`actions/checkout@v4`, `docker/build-push-action@v6`, …). Those are widely-used, well-maintained
actions and the risk is much lower, but the failure mode is the same one that bit us here. Pinning
by SHA with Dependabot updates is the usual answer if you want to close it off; out of scope for this
PR.

## Self review

- [ ] Claude
- [ ] Codex
