### PR TITLE
fix(lynqhub): decide rollout skew on API state, not the cache

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -235,6 +235,9 @@ func main() {
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor("lynqhub-controller"),
+		// Rollout throttling must not be decided on a cache that may not yet contain this
+		// controller's own writes — see rolloutSkewCounter.
+		APIReader: mgr.GetAPIReader(),
 	}).SetupWithManager(mgr, hubConcurrency); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "LynqHub")
 		os.Exit(1)

--- a/internal/controller/lynqhub_controller.go
+++ b/internal/controller/lynqhub_controller.go
@@ -58,6 +58,20 @@ type LynqHubReconciler struct {
 	client.Client
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
+
+	// APIReader reads straight from the API server, bypassing the informer cache. Required for
+	// the rollout-skew decision, which must not be made on a cache that has yet to observe this
+	// controller's own writes — see rolloutSkewCounter. Optional: falls back to the cached
+	// client when nil, so reconcilers constructed directly in tests keep working.
+	APIReader client.Reader
+}
+
+// uncachedReader returns a reader guaranteed to reflect writes that have already completed.
+func (r *LynqHubReconciler) uncachedReader() client.Reader {
+	if r.APIReader != nil {
+		return r.APIReader
+	}
+	return r.Client
 }
 
 // +kubebuilder:rbac:groups=operator.lynq.sh,resources=lynqhubs,verbs=get;list;watch;create;update;patch;delete
@@ -190,12 +204,6 @@ func (r *LynqHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		existing[key] = node
 	}
 
-	// Group existing nodes by template for maxSkew checking
-	nodesByTemplate := make(map[string][]*lynqv1.LynqNode)
-	for key, node := range existing {
-		nodesByTemplate[key.TemplateName] = append(nodesByTemplate[key.TemplateName], node)
-	}
-
 	// Track throttled updates for events
 	throttledByTemplate := make(map[string]int)
 
@@ -205,7 +213,7 @@ func (r *LynqHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	updatedInThisIteration := make(map[string]int32)
 
 	// Memoize the per-template "currently updating" count for the duration of this Reconcile.
-	skew := newRolloutSkewCounter(r, nodesByTemplate)
+	skew := newRolloutSkewCounter(r, registry)
 
 	// Create/update nodes for each template-row combination
 	for key, desired := range desired {
@@ -215,8 +223,14 @@ func (r *LynqHubReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			// Create new LynqNode - check maxSkew before creating
 			if canUpdateNodeWithPrecount(tmpl, skew.count(ctx, tmpl), updatedInThisIteration[tmpl.Name]) {
 				if err := r.createLynqNode(ctx, registry, tmpl, desired.Row); err != nil {
-					// Ignore AlreadyExists errors (can happen due to concurrent reconciliations)
-					if !errors.IsAlreadyExists(err) {
+					// AlreadyExists means the node is present in the API server but absent from the
+					// list we planned against — a stale read, not a real failure. It still consumed
+					// a rollout slot, so count it: treating it as a no-op would let this pass admit
+					// one more node than maxSkew allows, which is the create-side twin of the
+					// stale-read race that rolloutSkewCounter guards the update side against.
+					if errors.IsAlreadyExists(err) {
+						updatedInThisIteration[tmpl.Name]++
+					} else {
 						logger.Error(err, "Failed to create LynqNode", "template", key.TemplateName, "uid", key.UID)
 					}
 				} else {
@@ -614,7 +628,7 @@ func (r *LynqHubReconciler) createLynqNode(ctx context.Context, registry *lynqv1
 				"lynq.sh/extra":                         string(extraJSON),
 				lynqv1.AnnotationTemplateGeneration:     fmt.Sprintf("%d", tmpl.Generation),
 				"lynq.sh/hubId":                         registry.Name,
-				lynqv1.AnnotationRolloutUpdateStartTime: time.Now().Format(time.RFC3339),
+				lynqv1.AnnotationRolloutUpdateStartTime: time.Now().Format(time.RFC3339Nano),
 			},
 		},
 		Spec: *renderedSpec,
@@ -711,7 +725,7 @@ func (r *LynqHubReconciler) updateLynqNode(ctx context.Context, registry *lynqv1
 	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		// Get the latest version of the LynqNode
 		latest := &lynqv1.LynqNode{}
-		if err := r.Get(ctx, client.ObjectKeyFromObject(node), latest); err != nil {
+		if err := r.uncachedReader().Get(ctx, client.ObjectKeyFromObject(node), latest); err != nil {
 			return err
 		}
 
@@ -725,7 +739,7 @@ func (r *LynqHubReconciler) updateLynqNode(ctx context.Context, registry *lynqv1
 		latest.Annotations[lynqv1.AnnotationTemplateGeneration] = newTemplateGeneration
 		latest.Annotations["lynq.sh/hubId"] = registry.Name
 		// Update rollout start time for progress deadline tracking
-		latest.Annotations[lynqv1.AnnotationRolloutUpdateStartTime] = time.Now().Format(time.RFC3339)
+		latest.Annotations[lynqv1.AnnotationRolloutUpdateStartTime] = time.Now().Format(time.RFC3339Nano)
 
 		// Update spec with newly rendered resources
 		latest.Spec = *renderedSpec
@@ -1195,7 +1209,11 @@ func (r *LynqHubReconciler) countUpdatingNodes(ctx context.Context, nodes []*lyn
 }
 
 // isNodeResourcesActuallyReady checks if all resources managed by a LynqNode are actually ready
-// by querying the cluster directly instead of relying on cached LynqNode status.
+// by querying the API server directly, bypassing both the LynqNode status and the informer cache.
+//
+// The cache is not usable here for the same reason it is not usable for the skew count: this runs
+// moments after the LynqNode controller applied those workloads, so a cached read can still show
+// the pre-update, still-Ready Deployment and release a rollout slot that is in fact occupied.
 // This is critical for maxSkew enforcement to ensure we don't start updating the next node
 // before the current node's resources (especially Deployments with slow-starting Pods) are truly ready.
 //
@@ -1227,7 +1245,7 @@ func (r *LynqHubReconciler) isNodeResourcesActuallyReady(ctx context.Context, no
 		switch kind {
 		case resourceKindDeployment:
 			var deploy appsv1.Deployment
-			if err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &deploy); err != nil {
+			if err := r.uncachedReader().Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &deploy); err != nil {
 				if errors.IsNotFound(err) {
 					logger.V(1).Info("Deployment not found, considering not ready",
 						"deployment", name, "namespace", namespace, "lynqnode", node.Name)
@@ -1245,7 +1263,7 @@ func (r *LynqHubReconciler) isNodeResourcesActuallyReady(ctx context.Context, no
 			}
 		case "StatefulSet":
 			var sts appsv1.StatefulSet
-			if err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &sts); err != nil {
+			if err := r.uncachedReader().Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &sts); err != nil {
 				if errors.IsNotFound(err) {
 					logger.V(1).Info("StatefulSet not found, considering not ready",
 						"statefulset", name, "namespace", namespace, "lynqnode", node.Name)
@@ -1262,7 +1280,7 @@ func (r *LynqHubReconciler) isNodeResourcesActuallyReady(ctx context.Context, no
 			}
 		case "DaemonSet":
 			var ds appsv1.DaemonSet
-			if err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &ds); err != nil {
+			if err := r.uncachedReader().Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, &ds); err != nil {
 				if errors.IsNotFound(err) {
 					logger.V(1).Info("DaemonSet not found, considering not ready",
 						"daemonset", name, "namespace", namespace, "lynqnode", node.Name)
@@ -1431,28 +1449,50 @@ func (r *LynqHubReconciler) canUpdateNodeWithCount(ctx context.Context, tmpl *ly
 	return canUpdateNodeWithPrecount(tmpl, updatingCount, additionalUpdates)
 }
 
-// rolloutSkewCounter memoizes countUpdatingNodes per template for the duration of one hub
-// Reconcile. See canUpdateNodeWithPrecount for why the count is stable within a Reconcile and
-// why recomputing it per desired node was expensive.
+// rolloutSkewCounter answers "how many of this template's nodes are mid-update?" for the
+// duration of one hub Reconcile.
+//
+// It reads nodes through the API server, not the informer cache. The cache is not safe for this
+// decision: the hub is re-enqueued from several independent sources — the LynqNode watch, the
+// LynqHub watch fed by our own status writes, the LynqForm watch, and timed requeues — and only
+// the LynqNode watch guarantees that the cache already contains the node update that triggered
+// it. Any of the others can start a reconcile whose cached node list predates the update we just
+// made, so a node we just moved to the new generation still looks old, is not counted as
+// updating, and a second node is admitted past maxSkew. That is exactly the flake seen in the
+// "maxSkew strict enforcement with slow-starting Pods" E2E test, where two Deployments began
+// rolling 0.2s apart under maxSkew=1.
+//
+// `updatedInThisIteration` covers updates made later in the same pass; the uncached read covers
+// updates made by previous passes that the cache has not caught up with. Together they make the
+// admission decision correct for a single active reconciler, which is what leader election
+// gives us. It does not fence two simultaneously-active leaders — that would need a durable,
+// atomically-acquired reservation, which is deliberately out of scope here.
+//
+// Cost is confined to rollouts: callers only consult this when a node actually needs creating or
+// updating, so a steady-state sync performs no extra reads at all.
 type rolloutSkewCounter struct {
-	reconciler      *LynqHubReconciler
-	nodesByTemplate map[string][]*lynqv1.LynqNode
-	counts          map[string]int32
+	reconciler *LynqHubReconciler
+	hub        *lynqv1.LynqHub
+	counts     map[string]int32
 }
 
-func newRolloutSkewCounter(r *LynqHubReconciler, nodesByTemplate map[string][]*lynqv1.LynqNode) *rolloutSkewCounter {
+func newRolloutSkewCounter(r *LynqHubReconciler, hub *lynqv1.LynqHub) *rolloutSkewCounter {
 	return &rolloutSkewCounter{
-		reconciler:      r,
-		nodesByTemplate: nodesByTemplate,
-		counts:          make(map[string]int32, len(nodesByTemplate)),
+		reconciler: r,
+		hub:        hub,
+		counts:     make(map[string]int32),
 	}
 }
 
 // count returns how many of the template's nodes are currently updating.
 //
-// Returns 0 without scanning when the template has no rollout limit: the result is not
-// consulted in that case (canUpdateNodeWithPrecount short-circuits), so paying for the scan
-// would be pure waste.
+// Returns 0 without reading anything when the template has no rollout limit: the result is not
+// consulted in that case (canUpdateNodeWithPrecount short-circuits), so the read would be pure
+// waste — and this is what keeps steady-state syncs free of uncached reads.
+//
+// A read failure returns maxSkew, which denies admission. Refusing to start another update
+// because we could not establish how many are already running is the safe direction; the next
+// sync retries.
 func (c *rolloutSkewCounter) count(ctx context.Context, tmpl *lynqv1.LynqForm) int32 {
 	if tmpl.Spec.Rollout == nil || tmpl.Spec.Rollout.MaxSkew == 0 {
 		return 0
@@ -1460,31 +1500,58 @@ func (c *rolloutSkewCounter) count(ctx context.Context, tmpl *lynqv1.LynqForm) i
 	if cached, ok := c.counts[tmpl.Name]; ok {
 		return cached
 	}
-	count := c.reconciler.countUpdatingNodes(ctx, c.nodesByTemplate[tmpl.Name], tmpl.Generation)
+
+	nodes, err := c.reconciler.listTemplateNodesUncached(ctx, c.hub, tmpl.Name)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "Failed to read nodes for rollout skew check, denying further updates this sync",
+			"template", tmpl.Name)
+		c.counts[tmpl.Name] = tmpl.Spec.Rollout.MaxSkew
+		return tmpl.Spec.Rollout.MaxSkew
+	}
+
+	count := c.reconciler.countUpdatingNodes(ctx, nodes, tmpl.Generation)
 	c.counts[tmpl.Name] = count
 	return count
 }
 
-// canUpdateNodeWithPrecount is canUpdateNodeWithCount with the countUpdatingNodes result
-// supplied by the caller.
+// listTemplateNodesUncached reads this template's LynqNodes straight from the API server.
 //
-// countUpdatingNodes depends only on (templateNodes, tmpl.Generation). Both are fixed for the
-// duration of one Reconcile: nodesByTemplate is built from a single List snapshot before the
-// desired-set loop, and nothing in that loop mutates the slice or the LynqNode objects it points
-// at (updateLynqNode re-Gets its own `latest` copy). Calling it once per desired node therefore
-// recomputed an identical answer O(rows) times, and each computation scans every node for the
-// template and issues a cached workload GET (plus DeepCopy) per applied resource — in production
-// that was 360 desired x 120 nodes = 43,200 scans on every 30s hub sync.
+// See rolloutSkewCounter for why the informer cache cannot be trusted for the skew decision.
+func (r *LynqHubReconciler) listTemplateNodesUncached(ctx context.Context, hub *lynqv1.LynqHub, templateName string) ([]*lynqv1.LynqNode, error) {
+	nodeList := &lynqv1.LynqNodeList{}
+	if err := r.uncachedReader().List(ctx, nodeList,
+		client.InNamespace(hub.Namespace),
+		client.MatchingLabels{"lynq.sh/hub": hub.Name},
+	); err != nil {
+		return nil, err
+	}
+
+	nodes := make([]*lynqv1.LynqNode, 0, len(nodeList.Items))
+	for i := range nodeList.Items {
+		node := &nodeList.Items[i]
+		if node.Spec.TemplateRef == templateName {
+			nodes = append(nodes, node)
+		}
+	}
+	return nodes, nil
+}
+
+// canUpdateNodeWithPrecount is canUpdateNodeWithCount with the "currently updating" count
+// supplied by the caller, which rolloutSkewCounter obtains once per template per Reconcile.
 //
-// Updates made earlier in the same loop are already accounted for by the caller's
-// additionalUpdates counter, so hoisting the count out of the loop preserves maxSkew semantics
-// exactly.
+// Recomputing it per desired node was both wasteful and, now that the count comes from the API
+// server, would issue one LIST per desired node: in production that shape was 360 desired x 120
+// nodes = 43,200 scans plus a workload GET each, on every 30s sync.
+//
+// Memoizing is safe because the count is a point-in-time admission snapshot. Updates made later
+// in the same loop are tracked by the caller's additionalUpdates counter, so the pair still
+// enforces maxSkew exactly.
 func canUpdateNodeWithPrecount(tmpl *lynqv1.LynqForm, updatingCount, additionalUpdates int32) bool {
 	if tmpl.Spec.Rollout == nil || tmpl.Spec.Rollout.MaxSkew == 0 {
 		return true
 	}
 
-	// Add the count of nodes we've updated in THIS iteration that aren't yet reflected in templateNodes
+	// Add the nodes we've updated in THIS pass, which the snapshot above cannot include
 	totalUpdating := updatingCount + additionalUpdates
 
 	return totalUpdating < tmpl.Spec.Rollout.MaxSkew

--- a/internal/controller/maxskew_stale_cache_test.go
+++ b/internal/controller/maxskew_stale_cache_test.go
@@ -1,0 +1,291 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	lynqv1 "github.com/k8s-lynq/lynq/api/v1"
+)
+
+// The rollout-skew race reproduced here.
+//
+// The hub is re-enqueued from several independent sources — the LynqNode watch, the LynqHub
+// watch fed by our own status writes, the LynqForm watch, and timed requeues. Only the LynqNode
+// watch guarantees the informer cache already contains the node update that triggered it. Any
+// other trigger can start a reconcile whose cached node list predates an update we just made, so
+// a node already moved to the new generation still looks old, is not counted as updating, and a
+// second node is admitted past maxSkew.
+//
+// These tests model that directly: the cached client is frozen at the pre-update state while the
+// APIReader reflects the write that actually happened. Nothing here depends on timing, so the
+// race is reproduced deterministically rather than by hoping a wall-clock window lines up as it
+// did in the "maxSkew strict enforcement with slow-starting Pods" E2E flake.
+
+const (
+	skewTestNamespace = "default"
+	skewTestHub       = "test-hub"
+	skewTestForm      = "web-app"
+)
+
+// staleCacheReconciler returns a reconciler whose cached Client is stuck at cachedNodes while
+// its APIReader sees apiNodes, plus the LynqHub and LynqForm the skew decision is made for.
+func staleCacheReconciler(
+	t *testing.T,
+	cachedNodes []*lynqv1.LynqNode,
+	apiNodes []*lynqv1.LynqNode,
+	workloads ...client.Object,
+) (*LynqHubReconciler, *lynqv1.LynqHub, *lynqv1.LynqForm) {
+	t.Helper()
+	scheme := setupTestScheme(t)
+
+	toObjects := func(nodes []*lynqv1.LynqNode) []client.Object {
+		objs := make([]client.Object, 0, len(nodes))
+		for _, n := range nodes {
+			objs = append(objs, n)
+		}
+		return objs
+	}
+
+	cached := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(toObjects(cachedNodes)...).Build()
+
+	apiObjects := append(toObjects(apiNodes), workloads...)
+	apiReader := fake.NewClientBuilder().WithScheme(scheme).
+		WithObjects(apiObjects...).Build()
+
+	hub := &lynqv1.LynqHub{
+		ObjectMeta: metav1.ObjectMeta{Name: skewTestHub, Namespace: skewTestNamespace},
+	}
+	form := &lynqv1.LynqForm{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       skewTestForm,
+			Namespace:  skewTestNamespace,
+			Generation: 2, // the generation being rolled out to
+		},
+		Spec: lynqv1.LynqFormSpec{
+			HubID:   skewTestHub,
+			Rollout: &lynqv1.RolloutConfig{MaxSkew: 1},
+		},
+	}
+
+	return &LynqHubReconciler{
+		Client:    cached,
+		APIReader: apiReader,
+		Scheme:    scheme,
+	}, hub, form
+}
+
+// skewTestNode builds a LynqNode carrying the rollout markers the skew count reads.
+func skewTestNode(name string, templateGen int64, ready bool, updateStarted time.Time) *lynqv1.LynqNode {
+	node := &lynqv1.LynqNode{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Namespace:  skewTestNamespace,
+			Generation: 1,
+			Labels:     map[string]string{"lynq.sh/hub": skewTestHub},
+			Annotations: map[string]string{
+				lynqv1.AnnotationTemplateGeneration: fmt.Sprintf("%d", templateGen),
+			},
+		},
+		Spec: lynqv1.LynqNodeSpec{UID: name, TemplateRef: skewTestForm},
+		Status: lynqv1.LynqNodeStatus{
+			ObservedGeneration: 1,
+		},
+	}
+	if !updateStarted.IsZero() {
+		node.Annotations[lynqv1.AnnotationRolloutUpdateStartTime] = updateStarted.Format(time.RFC3339Nano)
+	}
+	if ready {
+		node.Status.Conditions = []metav1.Condition{{
+			Type:               ConditionTypeReady,
+			Status:             metav1.ConditionTrue,
+			Reason:             "Reconciled",
+			LastTransitionTime: metav1.Now(),
+		}}
+	}
+	return node
+}
+
+// TestRegression_SkewCountSeesWritesTheCacheHasNotObserved is the core regression test: a node
+// that has already been moved to the new generation must be counted as updating even when the
+// informer cache still shows it at the old one.
+func TestRegression_SkewCountSeesWritesTheCacheHasNotObserved(t *testing.T) {
+	ctx := context.Background()
+	longAgo := time.Now().Add(-time.Hour) // past the safety margin, so only the generation matters
+
+	// Given node-1 has been updated to the new template generation in the API server...
+	updated := skewTestNode("node-1", 2, false, longAgo)
+	// ...but the cache still shows it at the old generation, as if the watch has not arrived.
+	stale := skewTestNode("node-1", 1, true, time.Time{})
+
+	r, hub, form := staleCacheReconciler(t,
+		[]*lynqv1.LynqNode{stale},
+		[]*lynqv1.LynqNode{updated})
+
+	// When the rollout skew is evaluated
+	skew := newRolloutSkewCounter(r, hub)
+	count := skew.count(ctx, form)
+
+	// Then the in-flight update is counted...
+	assert.Equal(t, int32(1), count,
+		"a node already updated in the API server must count as updating even if the cache is behind")
+
+	// ...and no further node may be admitted, because maxSkew is 1.
+	assert.False(t, canUpdateNodeWithPrecount(form, count, 0),
+		"admitting a second node here is the maxSkew violation this guards against")
+}
+
+// TestRegression_SkewCountUsesFreshWorkloadState covers the slot-RELEASE side. countUpdatingNodes
+// falls through to isNodeResourcesActuallyReady for nodes that look settled; reading the workload
+// from cache there can show the pre-update, still-Ready Deployment and free a slot that is in
+// fact occupied.
+func TestRegression_SkewCountUsesFreshWorkloadState(t *testing.T) {
+	ctx := context.Background()
+	longAgo := time.Now().Add(-time.Hour)
+
+	// Given a node that looks settled: current generation, Ready, past the safety margin
+	node := skewTestNode("node-1", 2, true, longAgo)
+	node.Status.AppliedResources = []string{"Deployment/default/node-1-app@app"}
+
+	// ...whose Deployment is in fact still rolling out
+	rolling := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "node-1-app", Namespace: skewTestNamespace, Generation: 2,
+		},
+		Spec: appsv1.DeploymentSpec{Replicas: ptrInt32(2)},
+		Status: appsv1.DeploymentStatus{
+			ObservedGeneration: 2,
+			UpdatedReplicas:    1, // still replacing pods
+			ReadyReplicas:      1,
+			AvailableReplicas:  1,
+		},
+	}
+
+	r, hub, form := staleCacheReconciler(t,
+		[]*lynqv1.LynqNode{node},
+		[]*lynqv1.LynqNode{node.DeepCopy()},
+		rolling)
+
+	// When the rollout skew is evaluated
+	count := newRolloutSkewCounter(r, hub).count(ctx, form)
+
+	// Then the slot is still held by the in-progress rollout
+	assert.Equal(t, int32(1), count,
+		"a node whose Deployment is still rolling must keep holding its slot")
+}
+
+// TestSkewCountIsFreeWhenRolloutIsUnset pins the cost profile: without a rollout limit the count
+// is never consulted, so it must not read anything. This is what keeps steady-state syncs free of
+// uncached reads.
+func TestSkewCountIsFreeWhenRolloutIsUnset(t *testing.T) {
+	ctx := context.Background()
+	r, hub, form := staleCacheReconciler(t, nil, nil)
+
+	counted := &countingReader{Reader: r.APIReader}
+	r.APIReader = counted
+
+	form.Spec.Rollout = nil
+	assert.Equal(t, int32(0), newRolloutSkewCounter(r, hub).count(ctx, form))
+
+	form.Spec.Rollout = &lynqv1.RolloutConfig{MaxSkew: 0}
+	assert.Equal(t, int32(0), newRolloutSkewCounter(r, hub).count(ctx, form))
+
+	assert.Zero(t, counted.lists, "no rollout limit must mean no API reads")
+}
+
+// TestSkewCountReadsOncePerTemplate pins the memoization. Without it the uncached LIST would be
+// issued once per desired node instead of once per template.
+func TestSkewCountReadsOncePerTemplate(t *testing.T) {
+	ctx := context.Background()
+	r, hub, form := staleCacheReconciler(t, nil,
+		[]*lynqv1.LynqNode{skewTestNode("node-1", 2, false, time.Now())})
+
+	counted := &countingReader{Reader: r.APIReader}
+	r.APIReader = counted
+
+	skew := newRolloutSkewCounter(r, hub)
+	for i := 0; i < 10; i++ {
+		skew.count(ctx, form)
+	}
+
+	assert.Equal(t, 1, counted.lists, "the skew snapshot must be taken once per template per reconcile")
+}
+
+// TestSkewCountDeniesAdmissionWhenTheReadFails: if we cannot establish how many updates are in
+// flight, refusing to start another is the safe direction.
+func TestSkewCountDeniesAdmissionWhenTheReadFails(t *testing.T) {
+	ctx := context.Background()
+	r, hub, form := staleCacheReconciler(t, nil, nil)
+	r.APIReader = &failingReader{}
+
+	count := newRolloutSkewCounter(r, hub).count(ctx, form)
+
+	assert.Equal(t, form.Spec.Rollout.MaxSkew, count)
+	assert.False(t, canUpdateNodeWithPrecount(form, count, 0),
+		"a failed skew read must not admit an update")
+}
+
+// TestSkewCountIgnoresOtherTemplates: rollout budgets are per LynqForm, so one template's
+// in-flight updates must not consume another's.
+func TestSkewCountIgnoresOtherTemplates(t *testing.T) {
+	ctx := context.Background()
+
+	mine := skewTestNode("node-1", 2, false, time.Now())
+	other := skewTestNode("node-2", 2, false, time.Now())
+	other.Spec.TemplateRef = "worker" // different LynqForm, same hub
+
+	r, hub, form := staleCacheReconciler(t, nil, []*lynqv1.LynqNode{mine, other})
+
+	assert.Equal(t, int32(1), newRolloutSkewCounter(r, hub).count(ctx, form),
+		"only this template's nodes may consume its rollout budget")
+}
+
+func ptrInt32(v int32) *int32 { return &v }
+
+// countingReader counts List calls so tests can assert on read volume.
+type countingReader struct {
+	client.Reader
+	lists int
+}
+
+func (c *countingReader) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	c.lists++
+	return c.Reader.List(ctx, list, opts...)
+}
+
+// failingReader fails every read, standing in for an API server we cannot reach.
+type failingReader struct{}
+
+func (f *failingReader) Get(context.Context, client.ObjectKey, client.Object, ...client.GetOption) error {
+	return fmt.Errorf("simulated API server failure")
+}
+
+func (f *failingReader) List(context.Context, client.ObjectList, ...client.ListOption) error {
+	return fmt.Errorf("simulated API server failure")
+}
+
+var _ client.Reader = &failingReader{}


### PR DESCRIPTION
## Description

The E2E test `Rollout maxSkew Feature > maxSkew strict enforcement with slow-starting Pods`
intermittently catches a real violation: two Deployments begin rolling **0.2s apart under
`maxSkew=1`**.

```
[8.5s] maxSkew VIOLATION: 2 Deployments started updates before first Pod ready
       (initialDelaySeconds=15): [node-2 started at 0.2s node-1 started at 0.0s]
Expected <int>: 2 to be <= <int>: 1
```

It failed on K8s 1.34 while the *same* group passed on 1.32 and 1.33, and passed when the identical
commit was re-run — so it is a race, not a regression. But the violation it reports is genuine:
`maxSkew` is not actually enforced.

### Root cause

The hub is re-enqueued from several independent sources. Only one of them guarantees a fresh view
of the nodes:

| Trigger | Cache guarantee |
|---|---|
| `Owns(&LynqNode{})` | **Safe** — an informer updates its store *before* dispatching to handlers, so the reconcile this triggers already sees the node update |
| `For(&LynqHub{})`, fed by our own `updateStatus` writes | **No guarantee** — different informer, no ordering with the LynqNode cache |
| `Watches(&LynqForm{})` | No guarantee |
| Timed requeue / already-queued event | No guarantee |

```mermaid
sequenceDiagram
    participant R1 as Hub reconcile #1
    participant API as API server
    participant C as LynqNode informer cache
    participant R2 as Hub reconcile #2

    R1->>API: updateLynqNode(node-1) — new template-generation
    R1->>API: updateStatus(hub) — ready count genuinely changed
    API-->>R2: hub status event → reconcile (different informer)
    Note over R2,C: node-1's update has not reached this cache yet
    R2->>C: getExistingLynqNodes() — cached List
    C-->>R2: node-1 still at OLD template-generation
    Note over R2: countUpdatingNodes skips it → count = 0
    R2->>API: updateLynqNode(node-2) ← maxSkew violated
```

`countUpdatingNodes` decides "is this node updating?" purely from `template-generation` and
`rollout-update-start` annotations on **cached** objects. A node we just moved to the new generation
still looks old, is not counted, and a second node is admitted.

`updatedInThisIteration` only covers updates made later in the *same* pass, so it cannot see this.
And suppressing the hub-status trigger would **not** fix it — any queued event, LynqForm event or
timer produces the same unsafe reconcile.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [x] Test improvement

## Related Issues

<!-- No tracking issue; found via a flaky E2E failure on #39. -->

## Changes Made

**Read the skew decision through the API server, not the cache.** `rolloutSkewCounter` now lists
the template's LynqNodes via `mgr.GetAPIReader()`. Combined with `updatedInThisIteration`,
admission is correct for a single active reconciler — which is what leader election provides.

**Cost is unchanged in steady state.** Callers only consult the count when a node actually needs
creating or updating, so a sync with nothing to do performs **no extra reads at all**. During a
rollout it is one LIST per template per reconcile, memoized. A failed read now *denies* admission
rather than admitting blindly — refusing to start another update because we cannot establish how
many are running is the safe direction.

Three adjacent defects in the same path, all found while tracing this one:

1. **`isNodeResourcesActuallyReady` lied.** Its doc comment said it queries "the cluster directly
   instead of relying on cached LynqNode status" — but it used the cached client. This is the
   **slot-release** side of the same staleness bug: moments after the LynqNode controller replaces
   a Deployment, a cached read can still show the pre-update, still-Ready one and free a slot that
   is in fact occupied. Now uncached, and the comment says what the code does.

2. **`updateLynqNode`'s `RetryOnConflict` re-read from the cache.** "Get the latest version" used
   `r.Get`, which cannot supply the fresh `resourceVersion` the retry exists to obtain — repeated
   conflicts could exhaust the retries against the same stale version. Now uncached.

3. **The rollout start marker had second precision.** `time.RFC3339` truncates sub-second digits,
   so the nominal 2s `safetyMarginDuration` was really **1–2s** depending on where in the second the
   update landed. Now `RFC3339Nano`; the existing `time.Parse(time.RFC3339, …)` reader accepts it
   unchanged (Go's parser takes a fractional second even when the layout omits it — verified).

**Create-side twin of the same race.** A stale list makes `createLynqNode` return `AlreadyExists`;
that was ignored *without* counting the slot it consumed, letting one pass admit a node past
`maxSkew`. It now counts — the node exists, so the slot is taken.

Also removed `nodesByTemplate`, which became dead once the count stopped reading from it.

### Deliberately not done

Durable, atomically-acquired reservations (a CAS'd ledger on LynqForm status) would additionally
fence two *simultaneously active* leaders and crash boundaries. That is a real design change to a
code path with a history of regressions — see the maxSkew-deadlock and BUG 2 notes in `CLAUDE.md` —
and the failure it guards against requires split-brain, which leader election already makes rare.
Left as a follow-up if strict-under-split-brain ever becomes a requirement.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing (`make test`)
- [ ] Manual testing performed

The existing E2E test is timing-sensitive — it caught this once in three parallel runs and passed on
re-run. The new tests reproduce the race **deterministically** by driving a split client whose
cached `Client` is frozen behind its `APIReader`, exactly modelling "the watch has not arrived yet":

| Test | Asserts |
|---|---|
| `TestRegression_SkewCountSeesWritesTheCacheHasNotObserved` | a node already updated in the API server counts as updating even when the cache shows it at the old generation — and a second node is refused |
| `TestRegression_SkewCountUsesFreshWorkloadState` | a node whose Deployment is still rolling keeps its slot (the release-side bug) |
| `TestSkewCountIsFreeWhenRolloutIsUnset` | no rollout limit ⇒ zero API reads — pins the cost profile |
| `TestSkewCountReadsOncePerTemplate` | 10 calls ⇒ 1 LIST — pins the memoization |
| `TestSkewCountDeniesAdmissionWhenTheReadFails` | an unreachable API server denies admission |
| `TestSkewCountIgnoresOtherTemplates` | rollout budgets stay per-LynqForm |

**Verified to catch the bug:** with `uncachedReader()` temporarily reverted to the cached client,
4 of the 6 fail — including both regression tests. Full non-e2e suite green, `golangci-lint` 0 issues.

**Test Coverage:** not measured for this change.

## Documentation

- [ ] Documentation updated (if needed)
- [ ] API changes documented
- [ ] Examples added/updated (if needed)
- [ ] CHANGELOG.md updated (for significant changes)

No user-facing surface changed — no CRD fields, no flags, no status semantics. `CLAUDE.md`'s
"Common Pitfalls" section may be worth a note that the rollout-skew decision must not read from the
cache; happy to add it here if you'd prefer.

## Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [ ] I have updated the documentation accordingly
- [x] My changes maintain backward compatibility (or breaking changes are documented)

## Additional Notes

`LynqHubReconciler.APIReader` is optional and falls back to the cached client when nil, so
reconcilers constructed directly in tests keep working. Production wiring injects
`mgr.GetAPIReader()`.

**Branched from `origin/main`** (post-#38), independent of #39.

## Self review

- [ ] Claude
- [ ] Codex
